### PR TITLE
Correct github action caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,9 @@ jobs:
       env:
         cache-name: cache-cargo-build
       with:
-        path: target/develop/build
+        path: |
+          target/develop
+          ~/.cargo/registry
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
         cache-name: cache-cargo-build
       with:
         path: |
-          target/develop
+          target
           ~/.cargo/registry
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 authors = [
   "Guilhem Smith <gsmith@student.42.fr>",
   "Florian Bennetot <fbenneto@student.42.fr>",
-  "Tiago Lernould <tlernoul@student.42.fr>"
+  "Tiago Lernould <tlernoul@student.42.fr>",
+  "Cedric M'Passi <cedricmpassi@gmail.com>"
 ]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "gbmu"
 version = "0.1.0"
-authors = ["Guilhem Smith <gsmith@student.42.fr>"]
+authors = [
+  "Guilhem Smith <gsmith@student.42.fr>",
+  "Florian Bennetot <fbenneto@student.42.fr>"
+]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "gbmu"
 version = "0.1.0"
 authors = [
   "Guilhem Smith <gsmith@student.42.fr>",
-  "Florian Bennetot <fbenneto@student.42.fr>"
+  "Florian Bennetot <fbenneto@student.42.fr>",
+  "Tiago Lernould <tlernoul@student.42.fr>"
 ]
 edition = "2018"
 


### PR DESCRIPTION
add `~/.cargo/registry` to the cache.

Caching allow faster rebuild 

close #28 