### PR TITLE
Feature/read tile map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ version = "0.1.0"
 dependencies = [
  "egui",
  "gb-lcd",
+ "modular-bitfield",
  "sdl2",
 ]
 

--- a/gb-ppu/Cargo.toml
+++ b/gb-ppu/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 gb-lcd = { path = "../gb-lcd" }
+modular-bitfield = { version = "0.11" }
 
 [dev-dependencies]
 sdl2 = { version = "0.34", features = ["bundled", "static-link"] }

--- a/gb-ppu/examples/tilemap_viewer.rs
+++ b/gb-ppu/examples/tilemap_viewer.rs
@@ -7,12 +7,11 @@ pub fn main() {
     let (sdl_context, video_subsystem, mut event_pump) =
         gb_lcd::init().expect("Error while initializing LCD");
 
+    let bar_pixels_size = GBWindow::dots_to_pixels(&video_subsystem, render::MENU_BAR_SIZE)
+        .expect("Error while computing bar size");
     let mut gb_window = GBWindow::new(
         "TileSheet",
-        (
-            TILEMAP_DIM as u32,
-            TILEMAP_DIM as u32 + render::MENU_BAR_SIZE as u32,
-        ),
+        (TILEMAP_DIM as u32, TILEMAP_DIM as u32 + bar_pixels_size),
         true,
         &video_subsystem,
     )
@@ -25,7 +24,7 @@ pub fn main() {
         .expect("Failed to configure main window");
 
     let mut display =
-        render::RenderImage::<TILEMAP_DIM, TILEMAP_DIM>::with_bar_size(render::MENU_BAR_SIZE);
+        render::RenderImage::<TILEMAP_DIM, TILEMAP_DIM>::with_bar_size(bar_pixels_size as f32);
     let mut ppu = PPU::new();
     ppu.control_mut().set_bg_win_tiledata_area(1);
     let dumps = [

--- a/gb-ppu/examples/tilemap_viewer.rs
+++ b/gb-ppu/examples/tilemap_viewer.rs
@@ -27,7 +27,7 @@ pub fn main() {
     let mut display =
         render::RenderImage::<TILEMAP_DIM, TILEMAP_DIM>::with_bar_size(render::MENU_BAR_SIZE);
     let mut ppu = PPU::new();
-    ppu.control_mut().set_bg_win_tiledata_area(0);
+    ppu.control_mut().set_bg_win_tiledata_area(1);
     let dumps = [
         ("mario", include_bytes!("memory dumps/Super_Mario_Land.dmp")),
         (

--- a/gb-ppu/examples/tilemap_viewer.rs
+++ b/gb-ppu/examples/tilemap_viewer.rs
@@ -37,7 +37,8 @@ pub fn main() {
         ("pokemon", include_bytes!("memory dumps/Pokemon_Bleue.dmp")),
     ];
     ppu.overwrite_vram(dumps[0].1);
-    let mut image = ppu.tilemap_image();
+    let mut display_window = false;
+    let mut image = ppu.tilemap_image(display_window);
 
     'running: loop {
         gb_window
@@ -47,12 +48,24 @@ pub fn main() {
         egui::containers::TopBottomPanel::top("Top menu").show(gb_window.egui_ctx(), |ui| {
             egui::menu::bar(ui, |ui| {
                 ui.set_height(render::MENU_BAR_SIZE);
-                for (title, dump) in dumps {
-                    if ui.button(title).clicked() {
-                        ppu.overwrite_vram(dump);
-                        image = ppu.tilemap_image();
+                egui::menu::menu(ui, "dump", |ui| {
+                    for (title, dump) in dumps {
+                        if ui.button(title).clicked() {
+                            ppu.overwrite_vram(dump);
+                            image = ppu.tilemap_image(display_window);
+                        }
                     }
-                }
+                });
+                egui::menu::menu(ui, "bg/win", |ui| {
+                    if ui.button("background").clicked() {
+                        display_window = false;
+                        image = ppu.tilemap_image(display_window);
+                    }
+                    if ui.button("window").clicked() {
+                        display_window = true;
+                        image = ppu.tilemap_image(display_window);
+                    }
+                });
             })
         });
         display.update_render(&image);

--- a/gb-ppu/examples/tilemap_viewer.rs
+++ b/gb-ppu/examples/tilemap_viewer.rs
@@ -1,0 +1,98 @@
+use sdl2::{event::Event, keyboard::Keycode};
+
+use gb_lcd::{render, window::GBWindow};
+use gb_ppu::{PPU, TILEMAP_DIM};
+
+pub fn main() {
+    let (sdl_context, video_subsystem, mut event_pump) =
+        gb_lcd::init().expect("Error while initializing LCD");
+
+    let mut gb_window = GBWindow::new(
+        "TileSheet",
+        (
+            TILEMAP_DIM as u32,
+            TILEMAP_DIM as u32 + render::MENU_BAR_SIZE as u32,
+        ),
+        true,
+        &video_subsystem,
+    )
+    .expect("Error while building main window");
+    let (width, height) = gb_window.sdl_window().size();
+
+    gb_window
+        .sdl_window_mut()
+        .set_minimum_size(width, height)
+        .expect("Failed to configure main window");
+
+    let mut display =
+        render::RenderImage::<TILEMAP_DIM, TILEMAP_DIM>::with_bar_size(render::MENU_BAR_SIZE);
+    let mut ppu = PPU::new();
+    ppu.control_mut().set_bg_win_tiledata_area(0);
+    let dumps = [
+        ("mario", include_bytes!("memory dumps/Super_Mario_Land.dmp")),
+        (
+            "zelda",
+            include_bytes!("memory dumps/Legend_of_Zelda_link_Awaking.dmp"),
+        ),
+        ("pokemon", include_bytes!("memory dumps/Pokemon_Bleue.dmp")),
+    ];
+    ppu.overwrite_vram(dumps[0].1);
+    let mut image = ppu.tilemap_image();
+
+    'running: loop {
+        gb_window
+            .start_frame()
+            .expect("Fail at the start for the main window");
+
+        egui::containers::TopBottomPanel::top("Top menu").show(gb_window.egui_ctx(), |ui| {
+            egui::menu::bar(ui, |ui| {
+                ui.set_height(render::MENU_BAR_SIZE);
+                for (title, dump) in dumps {
+                    if ui.button(title).clicked() {
+                        ppu.overwrite_vram(dump);
+                        image = ppu.tilemap_image();
+                    }
+                }
+            })
+        });
+        display.update_render(&image);
+        display.draw();
+        gb_window
+            .end_frame()
+            .expect("Fail at the end for the main window");
+
+        for event in event_pump.poll_iter() {
+            match event {
+                Event::Quit { .. }
+                | Event::KeyDown {
+                    keycode: Some(Keycode::Escape),
+                    ..
+                } => break 'running,
+                Event::Window {
+                    win_event,
+                    window_id,
+                    ..
+                } => match win_event {
+                    sdl2::event::WindowEvent::SizeChanged(width, height) => {
+                        if gb_window.sdl_window().id() == window_id {
+                            gb_window
+                                .resize((width as u32, height as u32), &video_subsystem)
+                                .expect("Fail to resize example window");
+                            display.resize(gb_window.sdl_window().size());
+                        }
+                    }
+                    sdl2::event::WindowEvent::Close => {
+                        if gb_window.sdl_window().id() == window_id {
+                            break 'running;
+                        }
+                    }
+                    _ => {}
+                },
+                _ => {
+                    gb_window.send_event(&event, &sdl_context);
+                }
+            }
+        }
+        // std::thread::sleep(::std::time::Duration::new(0, 1_000_000_000u32 / 60));
+    }
+}

--- a/gb-ppu/examples/tilemap_viewer.rs
+++ b/gb-ppu/examples/tilemap_viewer.rs
@@ -38,6 +38,8 @@ pub fn main() {
     ];
     ppu.overwrite_vram(dumps[0].1);
     let mut display_window = false;
+    ppu.control_mut().set_win_tilemap_area(1);
+    ppu.control_mut().set_bg_tilemap_area(0);
     let mut image = ppu.tilemap_image(display_window);
 
     'running: loop {

--- a/gb-ppu/examples/tilesheet_viewer.rs
+++ b/gb-ppu/examples/tilesheet_viewer.rs
@@ -49,12 +49,14 @@ pub fn main() {
         egui::containers::TopBottomPanel::top("Top menu").show(gb_window.egui_ctx(), |ui| {
             egui::menu::bar(ui, |ui| {
                 ui.set_height(render::MENU_BAR_SIZE);
-                for (title, dump) in dumps {
-                    if ui.button(title).clicked() {
-                        ppu.overwrite_vram(dump);
-                        image = ppu.tilesheet_image();
+                egui::menu::menu(ui, "dump", |ui| {
+                    for (title, dump) in dumps {
+                        if ui.button(title).clicked() {
+                            ppu.overwrite_vram(dump);
+                            image = ppu.tilesheet_image();
+                        }
                     }
-                }
+                });
             })
         });
         display.update_render(&image);

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -1,8 +1,9 @@
 mod error;
 mod memory;
+mod ppu;
 mod registers;
 
-use gb_lcd::render::{RenderData, SCREEN_HEIGHT, SCREEN_WIDTH};
+pub use ppu::PPU;
 
 pub const TILESHEET_WIDTH: usize = 128;
 pub const TILESHEET_HEIGHT: usize = 192;
@@ -10,128 +11,3 @@ pub const TILESHEET_TILE_COUNT: usize = 16 * 24;
 
 pub const TILEMAP_DIM: usize = 256;
 pub const TILEMAP_TILE_COUNT: usize = 32 * 32;
-
-use memory::Vram;
-use registers::Control;
-
-/// Pixel Process Unit: is in charge of selecting the pixel to be displayed on the lcd screen.
-///
-/// Memory field (Vram, OAM) and registers owned by the ppu are simply exposed by public function when required for examples for now.
-/// This impl propably won't work once the cpu will need to access them.
-pub struct PPU {
-    vram: Vram,
-    control: Control,
-    pixels: RenderData<SCREEN_WIDTH, SCREEN_HEIGHT>,
-}
-
-impl PPU {
-    pub fn new() -> Self {
-        Self {
-            vram: Vram::new(),
-            control: Control::new(),
-            pixels: [[[255; 3]; SCREEN_WIDTH]; SCREEN_HEIGHT],
-        }
-    }
-
-    pub fn pixels(&self) -> &RenderData<SCREEN_WIDTH, SCREEN_HEIGHT> {
-        &self.pixels
-    }
-
-    pub fn control(&self) -> &Control {
-        &self.control
-    }
-
-    pub fn control_mut(&mut self) -> &mut Control {
-        &mut self.control
-    }
-
-    pub fn compute(&mut self) {
-        for j in 0..SCREEN_HEIGHT {
-            for i in 0..SCREEN_WIDTH {
-                if i == 0 || i == SCREEN_WIDTH - 1 || j == 0 || j == SCREEN_HEIGHT - 1 {
-                    self.pixels[j][i] = [255, 0, 0];
-                } else if (i + j) % 2 == 0 {
-                    self.pixels[j][i] = [0; 3];
-                } else {
-                    self.pixels[j][i] = [255; 3];
-                }
-            }
-        }
-    }
-
-    pub fn overwrite_vram(&mut self, data: &[u8; Vram::SIZE as usize]) {
-        self.vram.overwrite(data);
-    }
-
-    /// Create an image of the current tilesheet.
-    ///
-    /// This function is used for debugging purpose.
-    pub fn tilesheet_image(&self) -> RenderData<TILESHEET_WIDTH, TILESHEET_HEIGHT> {
-        let mut image = [[[255; 3]; TILESHEET_WIDTH]; TILESHEET_HEIGHT];
-        let mut x = 0;
-        let mut y = 0;
-        for k in 0..TILESHEET_TILE_COUNT {
-            let tile = self.vram.read_8x8_tile(k).unwrap();
-            for j in 0..8 {
-                for i in 0..8 {
-                    image[y * 8 + j][TILESHEET_WIDTH - (x + 1) * 8 + i] = match tile[j][i] {
-                        3 => [0; 3],
-                        2 => [85; 3],
-                        1 => [170; 3],
-                        0 => [255; 3],
-                        _ => [255; 3],
-                    }
-                }
-            }
-            x += 1;
-            if x * 8 >= TILESHEET_WIDTH {
-                x = 0;
-                y += 1;
-            }
-        }
-        image
-    }
-
-    /// Create an image of the current tilemap.
-    ///
-    /// This function is used for debugging purpose.
-    pub fn tilemap_image(&self) -> RenderData<TILEMAP_DIM, TILEMAP_DIM> {
-        let mut image = [[[255; 3]; TILEMAP_DIM]; TILEMAP_DIM];
-        let mut x = 0;
-        let mut y = 0;
-        for k in 0..TILEMAP_TILE_COUNT {
-            let index = self
-                .vram
-                .get_map_tile_index(
-                    k,
-                    self.control.bg_tilemap_area(),
-                    self.control.bg_win_tiledata_area(),
-                )
-                .unwrap();
-            let tile = self.vram.read_8x8_tile(index).unwrap();
-            for j in 0..8 {
-                for i in 0..8 {
-                    image[y * 8 + j][TILEMAP_DIM - (x + 1) * 8 + i] = match tile[j][i] {
-                        3 => [0; 3],
-                        2 => [85; 3],
-                        1 => [170; 3],
-                        0 => [255; 3],
-                        _ => [255; 3],
-                    }
-                }
-            }
-            x += 1;
-            if x * 8 >= TILEMAP_DIM {
-                x = 0;
-                y += 1;
-            }
-        }
-        image
-    }
-}
-
-impl Default for PPU {
-    fn default() -> PPU {
-        PPU::new()
-    }
-}

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -1,7 +1,10 @@
 mod error;
 mod memory;
+mod registers;
 
 use gb_lcd::render::{RenderData, SCREEN_HEIGHT, SCREEN_WIDTH};
+
+use registers::Control;
 
 pub const TILESHEET_WIDTH: usize = 128;
 pub const TILESHEET_HEIGHT: usize = 192;
@@ -10,6 +13,7 @@ use memory::{Vram, VRAM_SIZE};
 
 pub struct PPU {
     vram: Vram,
+    control: Control,
     pixels: RenderData<SCREEN_WIDTH, SCREEN_HEIGHT>,
 }
 
@@ -17,6 +21,7 @@ impl PPU {
     pub fn new() -> Self {
         Self {
             vram: Vram::new(),
+            control: Control::new(),
             pixels: [[[255; 3]; SCREEN_WIDTH]; SCREEN_HEIGHT],
         }
     }

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -4,8 +4,6 @@ mod registers;
 
 use gb_lcd::render::{RenderData, SCREEN_HEIGHT, SCREEN_WIDTH};
 
-use registers::Control;
-
 pub const TILESHEET_WIDTH: usize = 128;
 pub const TILESHEET_HEIGHT: usize = 192;
 pub const TILESHEET_TILE_COUNT: usize = 16 * 24;
@@ -13,7 +11,8 @@ pub const TILESHEET_TILE_COUNT: usize = 16 * 24;
 pub const TILEMAP_DIM: usize = 256;
 pub const TILEMAP_TILE_COUNT: usize = 32 * 32;
 
-use memory::{Vram, VRAM_SIZE};
+use memory::Vram;
+use registers::Control;
 
 /// Pixel Process Unit: is in charge of selecting the pixel to be displayed on the lcd screen.
 ///
@@ -60,7 +59,7 @@ impl PPU {
         }
     }
 
-    pub fn overwrite_vram(&mut self, data: &[u8; VRAM_SIZE as usize]) {
+    pub fn overwrite_vram(&mut self, data: &[u8; Vram::SIZE as usize]) {
         self.vram.overwrite(data);
     }
 

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -63,6 +63,9 @@ impl PPU {
         self.vram.overwrite(data);
     }
 
+    /// Create an image of the current tilesheet.
+    ///
+    /// This function is used for debugging purpose.
     pub fn tilesheet_image(&self) -> RenderData<TILESHEET_WIDTH, TILESHEET_HEIGHT> {
         let mut image = [[[255; 3]; TILESHEET_WIDTH]; TILESHEET_HEIGHT];
         let mut x = 0;
@@ -85,13 +88,13 @@ impl PPU {
                 x = 0;
                 y += 1;
             }
-            if y * 8 >= TILESHEET_HEIGHT {
-                return image;
-            }
         }
         image
     }
 
+    /// Create an image of the current tilemap.
+    ///
+    /// This function is used for debugging purpose.
     pub fn tilemap_image(&self) -> RenderData<TILEMAP_DIM, TILEMAP_DIM> {
         let mut image = [[[255; 3]; TILEMAP_DIM]; TILEMAP_DIM];
         let mut x = 0;
@@ -121,9 +124,6 @@ impl PPU {
             if x * 8 >= TILEMAP_DIM {
                 x = 0;
                 y += 1;
-            }
-            if y * 8 >= TILEMAP_DIM {
-                return image;
             }
         }
         image

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -72,14 +72,13 @@ impl PPU {
             let tile = self.vram.read_8x8_tile(k).unwrap();
             for j in 0..8 {
                 for i in 0..8 {
-                    image[y * 8 + j][TILESHEET_WIDTH - (x + 1) * 8 + i] =
-                        match tile[j as usize][i as usize] {
-                            3 => [0; 3],
-                            2 => [85; 3],
-                            1 => [170; 3],
-                            0 => [255; 3],
-                            _ => [255; 3],
-                        }
+                    image[y * 8 + j][TILESHEET_WIDTH - (x + 1) * 8 + i] = match tile[j][i] {
+                        3 => [0; 3],
+                        2 => [85; 3],
+                        1 => [170; 3],
+                        0 => [255; 3],
+                        _ => [255; 3],
+                    }
                 }
             }
             x += 1;
@@ -101,19 +100,22 @@ impl PPU {
         for k in 0..TILEMAP_TILE_COUNT {
             let index = self
                 .vram
-                .get_map_tile_index(k, self.control.bg_tilemap_area())
+                .get_map_tile_index(
+                    k,
+                    self.control.bg_tilemap_area(),
+                    self.control.bg_win_tiledata_area(),
+                )
                 .unwrap();
-            let tile = self.vram.read_8x8_tile(index as usize).unwrap();
+            let tile = self.vram.read_8x8_tile(index).unwrap();
             for j in 0..8 {
                 for i in 0..8 {
-                    image[y * 8 + j][TILEMAP_DIM - (x + 1) * 8 + i] =
-                        match tile[j as usize][i as usize] {
-                            3 => [0; 3],
-                            2 => [85; 3],
-                            1 => [170; 3],
-                            0 => [255; 3],
-                            _ => [255; 3],
-                        }
+                    image[y * 8 + j][TILEMAP_DIM - (x + 1) * 8 + i] = match tile[j][i] {
+                        3 => [0; 3],
+                        2 => [85; 3],
+                        1 => [170; 3],
+                        0 => [255; 3],
+                        _ => [255; 3],
+                    }
                 }
             }
             x += 1;

--- a/gb-ppu/src/memory.rs
+++ b/gb-ppu/src/memory.rs
@@ -1,3 +1,3 @@
 mod vram;
 
-pub use vram::{Vram, VRAM_SIZE};
+pub use vram::Vram;

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -7,6 +7,7 @@ const TILEDATA_START_1: usize = 0x1000 / 16;
 
 use crate::error::{Error, PPUResult};
 
+/// Contains operations to read more easily the differents values of the vram.
 pub struct Vram {
     data: [u8; VRAM_SIZE as usize],
 }
@@ -18,7 +19,12 @@ impl Vram {
         }
     }
 
-    /// return the index of a tile from the correct map area depending on the area_bit.
+    /// Return the index of a tile from the correct map area depending on the area_bits.
+    ///
+    /// ### Parameters
+    ///  - **pos**: the position of the index to retrieve in the tilemap.
+    ///  - **map_area_bit**: the control bit (bg_tilemap_area or win_tilemap_area) indicating in which block of the vram is stored the tilemap.
+    ///  - **data_area_bit**: the control bit (bg_win_tiledata_area) indicating in which block of the vram is stored the tilesheet for the background/window.
     pub fn get_map_tile_index(
         &self,
         pos: usize,
@@ -45,6 +51,10 @@ impl Vram {
         }
     }
 
+    /// Read a row of 8 pixels values contained in a couple of byte in the vram.
+    ///
+    /// ### Parameters
+    ///  - adr: adress pointing to the couple bytes to be interpreted as pixels values.
     pub fn read_8_pixels(&self, adr: usize) -> PPUResult<[u8; 8], usize> {
         let mut pixels = [0; 8];
         if adr > TILEDATA_ADRESS_MAX - 1 {
@@ -67,6 +77,12 @@ impl Vram {
         Ok(pixels)
     }
 
+    /// Return all the pixel values of a tile.
+    ///
+    /// This function is used for debugging purpose, the ppu does not select pixels tile by tile.
+    ///
+    /// ### Parameters
+    ///  - adr: adress pointing to the first byte of the tile.
     pub fn read_8x8_tile(&self, adr: usize) -> PPUResult<[[u8; 8]; 8], usize> {
         let mut tile = [[0; 8]; 8];
         if adr * 8 * 2 > TILEDATA_ADRESS_MAX + 1 - 8 * 2 {

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -1,11 +1,8 @@
 pub const VRAM_SIZE: usize = 0x2000;
 const TILEDATA_ADRESS_MAX: usize = 0x17FF;
-const TILEDATA_ADRESS_MIN: usize = 0x0000;
 const TILEMAP_POSITION_MAX: usize = 0x3FF;
-const TILEMAP_POSITION_MIN: usize = 0x0000;
 const TILEMAP_START_0: usize = 0x1800;
 const TILEMAP_START_1: usize = 0x1C00;
-const TILEDATA_START_0: usize = 0;
 const TILEDATA_START_1: usize = 0x1000 / 16;
 
 use crate::error::{Error, PPUResult};
@@ -31,7 +28,7 @@ impl Vram {
         if pos > TILEMAP_POSITION_MAX {
             return Err(Error::OutOfBound {
                 value: pos,
-                min_bound: TILEMAP_POSITION_MIN,
+                min_bound: 0,
                 max_bound: TILEMAP_POSITION_MAX,
             });
         }
@@ -41,7 +38,7 @@ impl Vram {
             self.data[TILEMAP_START_1 + pos]
         };
         if data_area_bit == 0 {
-            Ok(TILEDATA_START_0 + index as usize)
+            Ok(index as usize)
         } else {
             let index = index as i8;
             Ok((TILEDATA_START_1 as i32 + index as i32) as usize)
@@ -53,7 +50,7 @@ impl Vram {
         if adr > TILEDATA_ADRESS_MAX - 1 {
             return Err(Error::OutOfBound {
                 value: adr,
-                min_bound: TILEDATA_ADRESS_MIN,
+                min_bound: 0,
                 max_bound: TILEDATA_ADRESS_MAX - 1,
             });
         }
@@ -75,7 +72,7 @@ impl Vram {
         if adr * 8 * 2 > TILEDATA_ADRESS_MAX + 1 - 8 * 2 {
             return Err(Error::OutOfBound {
                 value: adr,
-                min_bound: TILEDATA_ADRESS_MIN,
+                min_bound: 0,
                 max_bound: TILEDATA_ADRESS_MAX / (8 * 2),
             });
         }

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -3,8 +3,8 @@ const TILEDATA_ADRESS_MAX: usize = 0x17FF;
 const TILEDATA_ADRESS_MIN: usize = 0x0000;
 const TILEMAP_POSITION_MAX: usize = 0x3FF;
 const TILEMAP_POSITION_MIN: usize = 0x0000;
-const TILEMAP_START_0: usize = 0x9800;
-const TILEMAP_START_1: usize = 0x9C00;
+const TILEMAP_START_0: usize = 0x1800;
+const TILEMAP_START_1: usize = 0x1C00;
 
 use crate::error::{Error, PPUResult};
 

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -1,6 +1,10 @@
 pub const VRAM_SIZE: usize = 0x2000;
 const TILEDATA_ADRESS_MAX: usize = 0x17FF;
 const TILEDATA_ADRESS_MIN: usize = 0x0000;
+const TILEMAP_POSITION_MAX: usize = 0x3FF;
+const TILEMAP_POSITION_MIN: usize = 0x0000;
+const TILEMAP_START_0: usize = 0x9800;
+const TILEMAP_START_1: usize = 0x9C00;
 
 use crate::error::{Error, PPUResult};
 
@@ -12,6 +16,22 @@ impl Vram {
     pub fn new() -> Self {
         Vram {
             data: [0x00; VRAM_SIZE as usize],
+        }
+    }
+
+    /// return the index of a tile from the correct map area depending on the area_bit.
+    pub fn get_map_tile_index(&self, pos: usize, area_bit: u8) -> PPUResult<u8, usize> {
+        if pos > TILEMAP_POSITION_MAX {
+            return Err(Error::OutOfBound {
+                value: pos,
+                min_bound: TILEMAP_POSITION_MIN,
+                max_bound: TILEMAP_POSITION_MAX,
+            });
+        }
+        if area_bit == 0 {
+            Ok(self.data[TILEMAP_START_0 + pos])
+        } else {
+            Ok(self.data[TILEMAP_START_1 + pos])
         }
     }
 

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -55,18 +55,18 @@ impl Vram {
     /// Read a row of 8 pixels values contained in a couple of byte in the vram.
     ///
     /// ### Parameters
-    ///  - adr: adress pointing to the couple bytes to be interpreted as pixels values.
-    pub fn read_8_pixels(&self, adr: usize) -> PPUResult<[u8; 8], usize> {
+    ///  - **pos**: position of the couple of bytes to be interpreted as pixels values.
+    pub fn read_8_pixels(&self, pos: usize) -> PPUResult<[u8; 8], usize> {
         let mut pixels = [0; 8];
-        if adr > TILEDATA_ADRESS_MAX - 1 {
+        if pos > TILEDATA_ADRESS_MAX - 1 {
             return Err(Error::OutOfBound {
-                value: adr,
+                value: pos,
                 min_bound: 0,
                 max_bound: TILEDATA_ADRESS_MAX - 1,
             });
         }
-        let byte_a = self.data[adr];
-        let byte_b = self.data[adr + 1];
+        let byte_a = self.data[pos];
+        let byte_b = self.data[pos + 1];
         for (i, pixel) in pixels.iter_mut().enumerate() {
             let bit = 0b0000_0001 << i;
             *pixel = if i > 0 {
@@ -83,18 +83,18 @@ impl Vram {
     /// This function is used for debugging purpose, the ppu does not select pixels tile by tile.
     ///
     /// ### Parameters
-    ///  - adr: adress pointing to the first byte of the tile.
-    pub fn read_8x8_tile(&self, adr: usize) -> PPUResult<[[u8; 8]; 8], usize> {
+    ///  - **pos**: position of the first byte of the tile.
+    pub fn read_8x8_tile(&self, pos: usize) -> PPUResult<[[u8; 8]; 8], usize> {
         let mut tile = [[0; 8]; 8];
-        if adr * 8 * 2 > TILEDATA_ADRESS_MAX + 1 - 8 * 2 {
+        if pos * 8 * 2 > TILEDATA_ADRESS_MAX + 1 - 8 * 2 {
             return Err(Error::OutOfBound {
-                value: adr,
+                value: pos,
                 min_bound: 0,
                 max_bound: TILEDATA_ADRESS_MAX / (8 * 2),
             });
         }
         for (i, row) in tile.iter_mut().enumerate() {
-            *row = self.read_8_pixels((adr * 8 + i) * 2)?;
+            *row = self.read_8_pixels((pos * 8 + i) * 2)?;
         }
         Ok(tile)
     }

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -5,6 +5,8 @@ const TILEMAP_POSITION_MAX: usize = 0x3FF;
 const TILEMAP_POSITION_MIN: usize = 0x0000;
 const TILEMAP_START_0: usize = 0x1800;
 const TILEMAP_START_1: usize = 0x1C00;
+const TILEDATA_START_0: usize = 0;
+const TILEDATA_START_1: usize = 0x1000 / 16;
 
 use crate::error::{Error, PPUResult};
 
@@ -20,7 +22,12 @@ impl Vram {
     }
 
     /// return the index of a tile from the correct map area depending on the area_bit.
-    pub fn get_map_tile_index(&self, pos: usize, area_bit: u8) -> PPUResult<u8, usize> {
+    pub fn get_map_tile_index(
+        &self,
+        pos: usize,
+        map_area_bit: u8,
+        data_area_bit: u8,
+    ) -> PPUResult<usize, usize> {
         if pos > TILEMAP_POSITION_MAX {
             return Err(Error::OutOfBound {
                 value: pos,
@@ -28,10 +35,16 @@ impl Vram {
                 max_bound: TILEMAP_POSITION_MAX,
             });
         }
-        if area_bit == 0 {
-            Ok(self.data[TILEMAP_START_0 + pos])
+        let index = if map_area_bit == 0 {
+            self.data[TILEMAP_START_0 + pos]
         } else {
-            Ok(self.data[TILEMAP_START_1 + pos])
+            self.data[TILEMAP_START_1 + pos]
+        };
+        if data_area_bit == 0 {
+            Ok(TILEDATA_START_0 + index as usize)
+        } else {
+            let index = index as i8;
+            Ok((TILEDATA_START_1 as i32 + index as i32) as usize)
         }
     }
 

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -1,21 +1,22 @@
-pub const VRAM_SIZE: usize = 0x2000;
-const TILEDATA_ADRESS_MAX: usize = 0x17FF;
-const TILEMAP_POSITION_MAX: usize = 0x3FF;
-const TILEMAP_START_0: usize = 0x1800;
-const TILEMAP_START_1: usize = 0x1C00;
-const TILEDATA_START_1: usize = 0x1000 / 16;
-
 use crate::error::{Error, PPUResult};
+
+pub const TILEDATA_ADRESS_MAX: usize = 0x17FF;
+pub const TILEMAP_POSITION_MAX: usize = 0x3FF;
+pub const TILEMAP_START_0: usize = 0x1800;
+pub const TILEMAP_START_1: usize = 0x1C00;
+pub const TILEDATA_START_1: usize = 0x1000 / 16;
 
 /// Contains operations to read more easily the differents values of the vram.
 pub struct Vram {
-    data: [u8; VRAM_SIZE as usize],
+    data: [u8; Vram::SIZE as usize],
 }
 
 impl Vram {
+    pub const SIZE: usize = 0x2000;
+
     pub fn new() -> Self {
         Vram {
-            data: [0x00; VRAM_SIZE as usize],
+            data: [0x00; Self::SIZE as usize],
         }
     }
 
@@ -98,7 +99,7 @@ impl Vram {
         Ok(tile)
     }
 
-    pub fn overwrite(&mut self, data: &[u8; VRAM_SIZE as usize]) {
+    pub fn overwrite(&mut self, data: &[u8; Self::SIZE as usize]) {
         self.data = *data;
     }
 }

--- a/gb-ppu/src/ppu.rs
+++ b/gb-ppu/src/ppu.rs
@@ -86,7 +86,7 @@ impl PPU {
     /// Create an image of the current tilemap.
     ///
     /// This function is used for debugging purpose.
-    pub fn tilemap_image(&self) -> RenderData<TILEMAP_DIM, TILEMAP_DIM> {
+    pub fn tilemap_image(&self, window: bool) -> RenderData<TILEMAP_DIM, TILEMAP_DIM> {
         let mut image = [[[255; 3]; TILEMAP_DIM]; TILEMAP_DIM];
         let mut x = 0;
         let mut y = 0;
@@ -95,7 +95,11 @@ impl PPU {
                 .vram
                 .get_map_tile_index(
                     k,
-                    self.control.bg_tilemap_area(),
+                    if !window {
+                        self.control.bg_tilemap_area()
+                    } else {
+                        self.control.win_tilemap_area()
+                    },
                     self.control.bg_win_tiledata_area(),
                 )
                 .unwrap();

--- a/gb-ppu/src/ppu.rs
+++ b/gb-ppu/src/ppu.rs
@@ -1,0 +1,128 @@
+use crate::memory::Vram;
+use crate::registers::Control;
+use crate::{
+    TILEMAP_DIM, TILEMAP_TILE_COUNT, TILESHEET_HEIGHT, TILESHEET_TILE_COUNT, TILESHEET_WIDTH,
+};
+use gb_lcd::render::{RenderData, SCREEN_HEIGHT, SCREEN_WIDTH};
+
+/// Pixel Process Unit: is in charge of selecting the pixel to be displayed on the lcd screen.
+///
+/// Memory field (Vram, OAM) and registers owned by the ppu are simply exposed by public function when required for examples for now.
+/// This impl propably won't work once the cpu will need to access them.
+pub struct PPU {
+    vram: Vram,
+    control: Control,
+    pixels: RenderData<SCREEN_WIDTH, SCREEN_HEIGHT>,
+}
+
+impl PPU {
+    pub fn new() -> Self {
+        Self {
+            vram: Vram::new(),
+            control: Control::new(),
+            pixels: [[[255; 3]; SCREEN_WIDTH]; SCREEN_HEIGHT],
+        }
+    }
+
+    pub fn pixels(&self) -> &RenderData<SCREEN_WIDTH, SCREEN_HEIGHT> {
+        &self.pixels
+    }
+
+    pub fn control(&self) -> &Control {
+        &self.control
+    }
+
+    pub fn control_mut(&mut self) -> &mut Control {
+        &mut self.control
+    }
+
+    pub fn compute(&mut self) {
+        for j in 0..SCREEN_HEIGHT {
+            for i in 0..SCREEN_WIDTH {
+                if i == 0 || i == SCREEN_WIDTH - 1 || j == 0 || j == SCREEN_HEIGHT - 1 {
+                    self.pixels[j][i] = [255, 0, 0];
+                } else if (i + j) % 2 == 0 {
+                    self.pixels[j][i] = [0; 3];
+                } else {
+                    self.pixels[j][i] = [255; 3];
+                }
+            }
+        }
+    }
+
+    pub fn overwrite_vram(&mut self, data: &[u8; Vram::SIZE as usize]) {
+        self.vram.overwrite(data);
+    }
+
+    /// Create an image of the current tilesheet.
+    ///
+    /// This function is used for debugging purpose.
+    pub fn tilesheet_image(&self) -> RenderData<TILESHEET_WIDTH, TILESHEET_HEIGHT> {
+        let mut image = [[[255; 3]; TILESHEET_WIDTH]; TILESHEET_HEIGHT];
+        let mut x = 0;
+        let mut y = 0;
+        for k in 0..TILESHEET_TILE_COUNT {
+            let tile = self.vram.read_8x8_tile(k).unwrap();
+            for j in 0..8 {
+                for i in 0..8 {
+                    image[y * 8 + j][TILESHEET_WIDTH - (x + 1) * 8 + i] = match tile[j][i] {
+                        3 => [0; 3],
+                        2 => [85; 3],
+                        1 => [170; 3],
+                        0 => [255; 3],
+                        _ => [255; 3],
+                    }
+                }
+            }
+            x += 1;
+            if x * 8 >= TILESHEET_WIDTH {
+                x = 0;
+                y += 1;
+            }
+        }
+        image
+    }
+
+    /// Create an image of the current tilemap.
+    ///
+    /// This function is used for debugging purpose.
+    pub fn tilemap_image(&self) -> RenderData<TILEMAP_DIM, TILEMAP_DIM> {
+        let mut image = [[[255; 3]; TILEMAP_DIM]; TILEMAP_DIM];
+        let mut x = 0;
+        let mut y = 0;
+        for k in 0..TILEMAP_TILE_COUNT {
+            let index = self
+                .vram
+                .get_map_tile_index(
+                    k,
+                    self.control.bg_tilemap_area(),
+                    self.control.bg_win_tiledata_area(),
+                )
+                .unwrap();
+            let tile = self.vram.read_8x8_tile(index).unwrap();
+            for j in 0..8 {
+                for i in 0..8 {
+                    image[y * 8 + j][TILEMAP_DIM - (x + 1) * 8 + i] = match tile[j][i] {
+                        3 => [0; 3],
+                        2 => [85; 3],
+                        1 => [170; 3],
+                        0 => [255; 3],
+                        _ => [255; 3],
+                    }
+                }
+            }
+            x += 1;
+            if x * 8 >= TILEMAP_DIM {
+                x = 0;
+                y += 1;
+            }
+        }
+        image
+    }
+}
+
+impl Default for PPU {
+    fn default() -> PPU {
+        PPU::new()
+    }
+}

--- a/gb-ppu/src/registers.rs
+++ b/gb-ppu/src/registers.rs
@@ -1,0 +1,3 @@
+mod control;
+
+pub use control::Control;

--- a/gb-ppu/src/registers/control.rs
+++ b/gb-ppu/src/registers/control.rs
@@ -1,0 +1,13 @@
+use modular_bitfield::{bitfield, specifiers::B1};
+
+#[bitfield]
+pub struct Control {
+    pub bg_win_enable: B1,
+    pub obj_enable: B1,
+    pub obj_size: B1,
+    pub bg_tilemap_area: B1,
+    pub bg_win_tiledata_area: B1,
+    pub win_enable: B1,
+    pub win_tilemap_area: B1,
+    pub ppu_enable: B1,
+}


### PR DESCRIPTION
### Tile map reading
Read the index from the tile map in the vram.  
It is used to generate the background and the window of the games.  

### Example
`cargo run --example tilemap_viewer -p gb-ppu`

close #43 