### PR TITLE
Bugfix/render incorrect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-debug = ["gb-lcd/debug"]
+debug_render = ["gb-lcd/debug_render"]
 
 [dependencies]
 sdl2 = { version = "0.34", features = ["bundled", "static-link"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+debug = ["gb-lcd/debug"]
+
 [dependencies]
 sdl2 = { version = "0.34", features = ["bundled", "static-link"] }
 egui = { version = "0.13" }

--- a/gb-lcd/Cargo.toml
+++ b/gb-lcd/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-debug = []
+debug_render = []
 
 [dependencies]
 sdl2 = { version = "0.34", features = ["bundled", "static-link"] }

--- a/gb-lcd/Cargo.toml
+++ b/gb-lcd/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+debug = []
+
 [dependencies]
 sdl2 = { version = "0.34", features = ["bundled", "static-link"] }
 egui = { version = "0.13" }

--- a/gb-lcd/src/render.rs
+++ b/gb-lcd/src/render.rs
@@ -82,6 +82,13 @@ impl<const WIDTH: usize, const HEIGHT: usize> RenderImage<WIDTH, HEIGHT> {
         }
     }
 
+    #[cfg(feature = "debug")]
+    pub fn switch_draw_mode(&self, lines: bool) {
+        unsafe {
+            gl::PolygonMode(gl::FRONT_AND_BACK, if lines { gl::LINE } else { gl::FILL });
+        }
+    }
+
     pub fn resize(&mut self, dim: (u32, u32)) {
         let dim = (dim.0 as f32, dim.1 as f32);
         let screen_ratio = WIDTH as f32 / HEIGHT as f32;
@@ -107,6 +114,10 @@ impl<const WIDTH: usize, const HEIGHT: usize> RenderImage<WIDTH, HEIGHT> {
         if screen_ratio > actual_ratio {
             self.offset.1 += 1.0 * (free_dim.1 - target_dim.1) / dim.1;
         }
+        println!("{:?};{:?}", dim.0, dim.1);
+        println!("{:?}:{:?}", free_dim.1, target_dim.1);
+        println!("{:?}:{:?}", self.scale.1, self.scale.1 * dim.1);
+        println!("{:?}:{:?}", self.offset.1, self.offset.1 * dim.1);
     }
 
     pub fn update_render(&mut self, texture_pixels: &RenderData<WIDTH, HEIGHT>) {

--- a/gb-lcd/src/render.rs
+++ b/gb-lcd/src/render.rs
@@ -82,7 +82,7 @@ impl<const WIDTH: usize, const HEIGHT: usize> RenderImage<WIDTH, HEIGHT> {
         }
     }
 
-    #[cfg(feature = "debug")]
+    #[cfg(feature = "debug_render")]
     pub fn switch_draw_mode(&self, lines: bool) {
         unsafe {
             gl::PolygonMode(gl::FRONT_AND_BACK, if lines { gl::LINE } else { gl::FILL });

--- a/gb-lcd/src/render.rs
+++ b/gb-lcd/src/render.rs
@@ -114,10 +114,6 @@ impl<const WIDTH: usize, const HEIGHT: usize> RenderImage<WIDTH, HEIGHT> {
         if screen_ratio > actual_ratio {
             self.offset.1 += 1.0 * (free_dim.1 - target_dim.1) / dim.1;
         }
-        println!("{:?};{:?}", dim.0, dim.1);
-        println!("{:?}:{:?}", free_dim.1, target_dim.1);
-        println!("{:?}:{:?}", self.scale.1, self.scale.1 * dim.1);
-        println!("{:?}:{:?}", self.offset.1, self.offset.1 * dim.1);
     }
 
     pub fn update_render(&mut self, texture_pixels: &RenderData<WIDTH, HEIGHT>) {

--- a/gb-lcd/src/window.rs
+++ b/gb-lcd/src/window.rs
@@ -16,6 +16,8 @@ pub struct GBWindow {
     egui_input_state: EguiInputState,
     pixels_per_point: f32,
     start_time: Instant,
+    #[cfg(feature = "debug")]
+    debug: bool,
 }
 
 impl GBWindow {
@@ -62,6 +64,8 @@ impl GBWindow {
             egui_input_state,
             pixels_per_point: native_pixels_per_point,
             start_time,
+            #[cfg(feature = "debug")]
+            debug: false,
         })
     }
 
@@ -89,6 +93,10 @@ impl GBWindow {
         unsafe {
             // Clear the screen to black
             gl::ClearColor(0.0, 0.0, 0.0, 1.0);
+            #[cfg(feature = "debug")]
+            if self.debug {
+                gl::ClearColor(1.0, 1.0, 1.0, 1.0);
+            }
             gl::Clear(gl::COLOR_BUFFER_BIT);
         };
         Ok(())
@@ -141,5 +149,10 @@ impl GBWindow {
             }
         }
         false
+    }
+
+    #[cfg(feature = "debug")]
+    pub fn set_debug(&mut self, debug: bool) {
+        self.debug = debug;
     }
 }

--- a/gb-lcd/src/window.rs
+++ b/gb-lcd/src/window.rs
@@ -161,8 +161,8 @@ impl GBWindow {
     pub fn dots_to_pixels(video_sys: &VideoSubsystem, dots: f32) -> Result<u32, Error> {
         Ok(
             (dots * RESOLUTION_DOT / video_sys.display_dpi(0).map_err(Error::GBWindowInit)?.0)
-                .round() as u32
-                + 3,
+                .ceil() as u32
+                + 4,
         )
     }
 }

--- a/gb-lcd/src/window.rs
+++ b/gb-lcd/src/window.rs
@@ -18,7 +18,7 @@ pub struct GBWindow {
     egui_input_state: EguiInputState,
     pixels_per_point: f32,
     start_time: Instant,
-    #[cfg(feature = "debug")]
+    #[cfg(feature = "debug_render")]
     debug: bool,
 }
 
@@ -66,7 +66,7 @@ impl GBWindow {
             egui_input_state,
             pixels_per_point: native_pixels_per_point,
             start_time,
-            #[cfg(feature = "debug")]
+            #[cfg(feature = "debug_render")]
             debug: false,
         })
     }
@@ -95,7 +95,7 @@ impl GBWindow {
         unsafe {
             // Clear the screen to black
             gl::ClearColor(0.0, 0.0, 0.0, 1.0);
-            #[cfg(feature = "debug")]
+            #[cfg(feature = "debug_render")]
             if self.debug {
                 gl::ClearColor(1.0, 1.0, 1.0, 1.0);
             }
@@ -153,7 +153,7 @@ impl GBWindow {
         false
     }
 
-    #[cfg(feature = "debug")]
+    #[cfg(feature = "debug_render")]
     pub fn set_debug(&mut self, debug: bool) {
         self.debug = debug;
     }

--- a/gb-lcd/src/window.rs
+++ b/gb-lcd/src/window.rs
@@ -8,6 +8,8 @@ use sdl2::{
 };
 use std::time::Instant;
 
+const RESOLUTION_DOT: f32 = 96.0;
+
 pub struct GBWindow {
     sdl_window: SdlWindow,
     gl_ctx: GLContext,
@@ -44,7 +46,7 @@ impl GBWindow {
         let egui_ctx = CtxRef::default();
 
         let native_pixels_per_point =
-            96f32 / video_sys.display_dpi(0).map_err(Error::GBWindowInit)?.0;
+            RESOLUTION_DOT / video_sys.display_dpi(0).map_err(Error::GBWindowInit)?.0;
 
         let egui_input_state = EguiInputState::new(egui::RawInput {
             screen_rect: Some(Rect::from_min_size(
@@ -154,5 +156,13 @@ impl GBWindow {
     #[cfg(feature = "debug")]
     pub fn set_debug(&mut self, debug: bool) {
         self.debug = debug;
+    }
+
+    pub fn dots_to_pixels(video_sys: &VideoSubsystem, dots: f32) -> Result<u32, Error> {
+        Ok(
+            (dots * RESOLUTION_DOT / video_sys.display_dpi(0).map_err(Error::GBWindowInit)?.0)
+                .round() as u32
+                + 3,
+        )
     }
 }

--- a/gb-ppu/examples/tilesheet_viewer.rs
+++ b/gb-ppu/examples/tilesheet_viewer.rs
@@ -7,11 +7,13 @@ pub fn main() {
     let (sdl_context, video_subsystem, mut event_pump) =
         gb_lcd::init().expect("Error while initializing LCD");
 
+    let bar_pixels_size = GBWindow::dots_to_pixels(&video_subsystem, render::MENU_BAR_SIZE)
+        .expect("Error while computing bar size");
     let mut gb_window = GBWindow::new(
         "TileSheet",
         (
             TILESHEET_WIDTH as u32,
-            TILESHEET_HEIGHT as u32 + render::MENU_BAR_SIZE as u32,
+            TILESHEET_HEIGHT as u32 + bar_pixels_size,
         ),
         true,
         &video_subsystem,
@@ -25,7 +27,7 @@ pub fn main() {
         .expect("Failed to configure main window");
 
     let mut display = render::RenderImage::<TILESHEET_WIDTH, TILESHEET_HEIGHT>::with_bar_size(
-        render::MENU_BAR_SIZE,
+        bar_pixels_size as f32,
     );
     let mut ppu = PPU::new();
     let dumps = [

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -30,8 +30,10 @@ impl PPU {
             for i in 0..SCREEN_WIDTH {
                 if i == 0 || i == SCREEN_WIDTH - 1 || j == 0 || j == SCREEN_HEIGHT - 1 {
                     self.pixels[j][i] = [255, 0, 0];
-                } else {
+                } else if (i + j) % 2 == 0 {
                     self.pixels[j][i] = [0; 3];
+                } else {
+                    self.pixels[j][i] = [255; 3];
                 }
             }
         }

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -26,28 +26,13 @@ impl PPU {
     }
 
     pub fn compute(&mut self) {
-        let mut x = 0;
-        let mut y = 0;
-        for k in 0..383 {
-            let tile = self.vram.read_8x8_tile(k).unwrap();
-            for j in 0..8 {
-                for i in 0..8 {
-                    self.pixels[y + j][x + i] = match tile[j as usize][i as usize] {
-                        3 => [0; 3],
-                        2 => [85; 3],
-                        1 => [170; 3],
-                        0 => [255; 3],
-                        _ => [255; 3],
-                    }
+        for j in 0..SCREEN_HEIGHT {
+            for i in 0..SCREEN_WIDTH {
+                if i == 0 || i == SCREEN_WIDTH - 1 || j == 0 || j == SCREEN_HEIGHT - 1 {
+                    self.pixels[j][i] = [255, 0, 0];
+                } else {
+                    self.pixels[j][i] = [0; 3];
                 }
-            }
-            x += 8;
-            if x >= SCREEN_WIDTH {
-                x = 0;
-                y += 8;
-            }
-            if y >= SCREEN_HEIGHT {
-                return;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@ use gb_dbg::app::Debugger;
 use gb_dbg::disassembler::Disassembler;
 use gb_dbg::flow_control::FlowController;
 use gb_dbg::memory::MemoryEditorBuilder;
+#[cfg(feature = "debug")]
+use sdl2::keyboard::Scancode;
+
 use gb_lcd::{render, window::GBWindow};
 use gb_ppu::PPU;
 
@@ -39,6 +42,9 @@ fn main() {
         .with_address_range("VRam", 0..0xFF)
         .build();
     let mut dbg_app = Debugger::new(gbm_mem, FlowController, Disassembler);
+
+    #[cfg(feature = "debug")]
+    let mut debug = false;
 
     'running: loop {
         gb_window
@@ -95,6 +101,20 @@ fn main() {
                     keycode: Some(Keycode::Escape),
                     ..
                 } => break 'running,
+                #[cfg(feature = "debug")]
+                sdl2::event::Event::KeyDown {
+                    window_id,
+                    scancode,
+                    ..
+                } => {
+                    if gb_window.sdl_window().id() == window_id && scancode == Some(Scancode::Grave)
+                    {
+                        println!("switch: {:?}", debug);
+                        debug = !debug;
+                        display.switch_draw_mode(debug);
+                        gb_window.set_debug(debug);
+                    }
+                }
                 Event::Window {
                     win_event,
                     window_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use gb_dbg::app::Debugger;
 use gb_dbg::disassembler::Disassembler;
 use gb_dbg::flow_control::FlowController;
 use gb_dbg::memory::MemoryEditorBuilder;
-#[cfg(feature = "debug")]
+#[cfg(feature = "debug_render")]
 use sdl2::keyboard::Scancode;
 
 use gb_lcd::{render, window::GBWindow};
@@ -45,7 +45,7 @@ fn main() {
         .build();
     let mut dbg_app = Debugger::new(gbm_mem, FlowController, Disassembler);
 
-    #[cfg(feature = "debug")]
+    #[cfg(feature = "debug_render")]
     let mut debug = false;
 
     'running: loop {
@@ -103,7 +103,7 @@ fn main() {
                     keycode: Some(Keycode::Escape),
                     ..
                 } => break 'running,
-                #[cfg(feature = "debug")]
+                #[cfg(feature = "debug_render")]
                 sdl2::event::Event::KeyDown {
                     window_id,
                     scancode,

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,6 @@ fn main() {
                 } => {
                     if gb_window.sdl_window().id() == window_id && scancode == Some(Scancode::Grave)
                     {
-                        println!("switch: {:?}", debug);
                         debug = !debug;
                         display.switch_draw_mode(debug);
                         gb_window.set_debug(debug);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,13 @@ fn main() {
     let (sdl_context, video_subsystem, mut event_pump) =
         gb_lcd::init().expect("Error while initializing LCD");
 
+    let bar_pixels_size = GBWindow::dots_to_pixels(&video_subsystem, render::MENU_BAR_SIZE)
+        .expect("Error while computing bar size");
     let mut gb_window = GBWindow::new(
         "GBMU",
         (
             render::SCREEN_WIDTH as u32,
-            render::SCREEN_HEIGHT as u32 + render::MENU_BAR_SIZE as u32,
+            render::SCREEN_HEIGHT as u32 + bar_pixels_size,
         ),
         true,
         &video_subsystem,
@@ -32,7 +34,7 @@ fn main() {
         .set_minimum_size(width, height)
         .expect("Failed to configure main window");
 
-    let mut display = render::Render::new();
+    let mut display = render::RenderImage::with_bar_size(bar_pixels_size as f32);
     let mut ppu = PPU::new();
 
     let mut debug_window = None;


### PR DESCRIPTION
The size of elements we specify to egui is not in pixel but in dots, which are the converted in pixels by the crate depending of the display [dpi](https://docs.rs/glutin/0.27.0/glutin/dpi/index.html).

A conversion was needed to add the size in pixel of the bar to the total height of the window.

close #49 