### PR TITLE
bugfix/Docker missing workspace member folder to build in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ COPY --chown=tester:tester gb-cpu/ /app/gb-cpu
 COPY --chown=tester:tester gb-lcd/ /app/gb-lcd/
 COPY --chown=tester:tester gb-ppu/ /app/gb-ppu/
 COPY --chown=tester:tester gb-roms/ /app/gb-roms/
+COPY --chown=tester:tester gb-bus/ /app/gb-bus/
+COPY --chown=tester:tester gb-dbg/ /app/gb-dbg/
 COPY --chown=tester:tester src/ /app/src/
 
 WORKDIR /app


### PR DESCRIPTION
- add missing workspace members `gb-dbg`, `gb-bus`