### PR TITLE
Feature/add log caps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,8 +737,10 @@ dependencies = [
  "gb-dbg",
  "gb-lcd",
  "gb-ppu",
+ "log",
  "rfd",
  "sdl2",
+ "simplelog",
 ]
 
 [[package]]
@@ -1255,6 +1270,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1703,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d0fe306a0ced1c88a58042dc22fc2ddd000982c26d75f6aa09a394547c41e0"
+dependencies = [
+ "chrono",
+ "log",
+ "termcolor",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1892,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ debug_render = ["gb-lcd/debug_render"]
 sdl2 = { version = "0.34", features = ["bundled", "static-link"] }
 egui = { version = "0.13" }
 rfd = { version = "0.4" }
+log = "0.4"
+simplelog = "0.10"
 gb-lcd = { path= "./gb-lcd" }
 gb-ppu = { path = "./gb-ppu" }
 gb-dbg = { path = "./gb-dbg" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,15 +166,9 @@ fn main() {
 #[cfg(debug_assertions)]
 fn init_logger() {
     use log::LevelFilter;
-    use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
+    use simplelog::Config;
 
-    TermLogger::init(
-        LevelFilter::Debug,
-        Config::default(),
-        TerminalMode::Mixed,
-        ColorChoice::Auto,
-    )
-    .expect("cannot initialise logger");
+    setup_terminal_logger(LevelFilter::Debug, Config::default());
 }
 
 #[cfg(not(debug_assertions))]
@@ -183,7 +177,36 @@ fn init_logger() {
     use simplelog::{Config, WriteLogger};
     use std::fs::File;
 
-    let file = File::create("/tmp/gbmu.log").expect("cannot open log file");
-    WriteLogger::init(LevelFilter::Warn, Config::default(), file)
-        .expect("cannot initialise logger");
+    const LEVEL_FILTER: LevelFilter = LevelFilter::Warn;
+    const LOG_FILE: &'static str = "/tmp/gbmu.log";
+    let config: Config = Config::default();
+    let file_res = File::create(LOG_FILE);
+
+    if let Ok(file) = file_res {
+        let write_logger_res = WriteLogger::init(LEVEL_FILTER, config.clone(), file);
+        if write_logger_res.is_ok() {
+            return;
+        } else {
+            setup_terminal_logger(LEVEL_FILTER, config);
+            log::warn!(
+                "cannot setup write logger (because: {})",
+                write_logger_res.unwrap_err()
+            );
+        }
+    } else {
+        setup_terminal_logger(LEVEL_FILTER, config);
+        log::warn!(
+            "cannot setup logging to file {} (because: {})",
+            LOG_FILE,
+            file_res.unwrap_err()
+        );
+    }
+    log::warn!("fallback to terminal logger");
+}
+
+fn setup_terminal_logger(level: log::LevelFilter, config: simplelog::Config) {
+    use simplelog::{ColorChoice, TermLogger, TerminalMode};
+
+    TermLogger::init(level, config, TerminalMode::Mixed, ColorChoice::Auto)
+        .expect("cannot setup terminal logger")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ use gb_lcd::{render, window::GBWindow};
 use gb_ppu::PPU;
 
 fn main() {
+    init_logger();
+
     let (sdl_context, video_subsystem, mut event_pump) =
         gb_lcd::init().expect("Error while initializing LCD");
 
@@ -157,4 +159,17 @@ fn main() {
         }
         // std::thread::sleep(::std::time::Duration::new(0, 1_000_000_000u32 / 60));
     }
+}
+
+fn init_logger() {
+    use log::LevelFilter;
+    use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
+
+    TermLogger::init(
+        LevelFilter::Debug,
+        Config::default(),
+        TerminalMode::Mixed,
+        ColorChoice::Auto,
+    )
+    .expect("cannot initialise logger");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ fn main() {
     log::info!("quitting");
 }
 
+#[cfg(debug_assertions)]
 fn init_logger() {
     use log::LevelFilter;
     use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
@@ -174,4 +175,15 @@ fn init_logger() {
         ColorChoice::Auto,
     )
     .expect("cannot initialise logger");
+}
+
+#[cfg(not(debug_assertions))]
+fn init_logger() {
+    use log::LevelFilter;
+    use simplelog::{Config, WriteLogger};
+    use std::fs::File;
+
+    let file = File::create("/tmp/gbmu.log").expect("cannot open log file");
+    WriteLogger::init(LevelFilter::Warn, Config::default(), file)
+        .expect("cannot initialise logger");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
                                 .unwrap_or_else(|_| std::path::PathBuf::from("/")),
                         )
                         .pick_file();
-                    println!("picked file: {:?}", files);
+                    log::debug!("picked file: {:?}", files);
                 }
                 if ui.button("Debug").clicked() && debug_window.is_none() {
                     debug_window = Some(
@@ -114,6 +114,7 @@ fn main() {
                     if gb_window.sdl_window().id() == window_id && scancode == Some(Scancode::Grave)
                     {
                         debug = !debug;
+                        log::debug!("toggle debug ({})", debug);
                         display.switch_draw_mode(debug);
                         gb_window.set_debug(debug);
                     }
@@ -159,6 +160,7 @@ fn main() {
         }
         // std::thread::sleep(::std::time::Duration::new(0, 1_000_000_000u32 / 60));
     }
+    log::info!("quitting");
 }
 
 fn init_logger() {


### PR DESCRIPTION
# Proposition: Add log capability to `GBMU`

TLDR: logging allow to trace the behavior of `GBMU`

## Why

- Allow to easily format log message instead of using `print` macros
- Give more information on the message printed thanks to `log::{debug, info, error, ...}` macros
- May help debug miss behaving `GBMU`

## Change TLDR

- use `log` crate interface
- use `simplelog` as log engine
  - use `TermLogger` to write log directly to `stdout/stderr`

