### PR TITLE
Feature/rework ticker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ dependencies = [
 name = "gb-joypad"
 version = "0.0.0"
 dependencies = [
- "egui",
+ "egui 0.13.1",
  "log",
  "modular-bitfield",
  "sdl2",

--- a/gb-clock/examples/capped.rs
+++ b/gb-clock/examples/capped.rs
@@ -30,12 +30,12 @@ struct FakeCPU {
     pub tick_count: usize,
 }
 
-impl Ticker<FakeBus> for FakeCPU {
+impl Ticker for FakeCPU {
     fn cycle_count(&self) -> Tick {
         Tick::MCycle
     }
 
-    fn tick(&mut self, _adr_bus: &mut FakeBus) {
+    fn tick<FakeBus>(&mut self, _adr_bus: &mut FakeBus) {
         self.tick_count += 1;
     }
 }
@@ -44,12 +44,12 @@ struct FakePPU {
     pub tick_count: usize,
 }
 
-impl Ticker<FakeBus> for FakePPU {
+impl Ticker for FakePPU {
     fn cycle_count(&self) -> Tick {
         Tick::TCycle
     }
 
-    fn tick(&mut self, _adr_bus: &mut FakeBus) {
+    fn tick<FakeBus>(&mut self, _adr_bus: &mut FakeBus) {
         self.tick_count += 1;
     }
 }

--- a/gb-clock/src/clock.rs
+++ b/gb-clock/src/clock.rs
@@ -14,7 +14,12 @@ impl<B: Bus<u8> + Bus<u16>> Clock<B> {
     pub const CYCLES_PER_FRAME: usize = 17556;
 
     /// A single clock cycle, during which each [Ticker] will tick 1 or 4 times depending on their [Tick](crate::Tick) type.
-    pub fn cycle(&mut self, adr_bus: &mut B, cpu: &mut dyn Ticker<B>, ppu: &mut dyn Ticker<B>) {
+    pub fn cycle<CPU: Ticker, PPU: Ticker>(
+        &mut self,
+        adr_bus: &mut B,
+        cpu: &mut CPU,
+        ppu: &mut PPU,
+    ) {
         cycle(cpu, adr_bus);
         cycle(ppu, adr_bus);
         self.curr_frame_cycle += 1;
@@ -29,12 +34,12 @@ impl<B: Bus<u8> + Bus<u16>> Clock<B> {
     /// Execute enough cycles to complete the current frame.
     ///
     /// if a [Debuger] is given, it will check breakpoints after each clock cycle and interrupt the execution if needed.
-    pub fn frame(
+    pub fn frame<CPU: Ticker, PPU: Ticker>(
         &mut self,
         adr_bus: &mut B,
         dbg: Option<&dyn Debuger<B>>,
-        cpu: &mut dyn Ticker<B>,
-        ppu: &mut dyn Ticker<B>,
+        cpu: &mut CPU,
+        ppu: &mut PPU,
     ) {
         self.curr_frame_cycle %= Self::CYCLES_PER_FRAME;
         match dbg {

--- a/gb-clock/src/ticker.rs
+++ b/gb-clock/src/ticker.rs
@@ -4,16 +4,22 @@ use gb_bus::Bus;
 /// Define the behavior of a process unit on a single tick.
 ///
 /// Each component implementing this trait will tick a fixed count T of times per clock cycle.
-pub trait Ticker<B: Bus<u8> + Bus<u16>> {
+pub trait Ticker {
     /// Return a [Tick] to identify the count T of tick amount per clock cycle.
     fn cycle_count(&self) -> Tick;
 
     /// The behavior called T times per clock cycle.
-    fn tick(&mut self, adr_bus: &mut B);
+    fn tick<B>(&mut self, adr_bus: &mut B)
+    where
+        B: Bus<u8> + Bus<u16>;
 }
 
 /// Execute X cycle depending of [Tick] type of the implementation of [Ticker]
-pub fn cycle<B: Bus<u8> + Bus<u16>>(ticker: &mut dyn Ticker<B>, adr_bus: &mut B) {
+pub fn cycle<T, B>(ticker: &mut T, adr_bus: &mut B)
+where
+    T: Ticker,
+    B: Bus<u8> + Bus<u16>,
+{
     for _ in 0..ticker.cycle_count().into() {
         ticker.tick(adr_bus);
     }


### PR DESCRIPTION
based on the suggestion #104

rework `Ticker` to move the generic to the method `Ticker::tick` because it's the only method that need the generic type

close #104