### PR TITLE
Bugfix/rtc naive not using instant

### DIFF
--- a/gb-rtc/src/constant.rs
+++ b/gb-rtc/src/constant.rs
@@ -1,5 +1,5 @@
-pub const MINUTE: u32 = 60;
-pub const HOUR: u32 = 60 * MINUTE;
-pub const DAY: u32 = 24 * HOUR;
-pub const MAX_DAYS: u32 = 0x1FF;
-pub const MAX_TIME: u32 = MAX_DAYS * DAY;
+pub const MINUTE: u64 = 60;
+pub const HOUR: u64 = 60 * MINUTE;
+pub const DAY: u64 = 24 * HOUR;
+pub const MAX_DAYS: u64 = 0x1FF;
+pub const MAX_TIME: u64 = MAX_DAYS * DAY;

--- a/gb-rtc/src/naive.rs
+++ b/gb-rtc/src/naive.rs
@@ -394,3 +394,35 @@ mod test_write_regs {
         assert_eq!(date.days(), 0);
     }
 }
+
+#[cfg(test)]
+mod test_ticking_clock {
+    use super::{Naive, ReadRtcRegisters, WriteRtcRegisters};
+    use std::thread::sleep;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn read() {
+        let mut clock = Naive::new(42);
+        clock.clock = Some(Instant::now());
+
+        sleep(Duration::from_secs(2));
+        let seconds = clock.seconds();
+        assert_eq!(seconds, 44);
+    }
+
+    #[test]
+    fn write() {
+        let mut clock = Naive::new(42);
+        clock.clock = Some(Instant::now());
+
+        sleep(Duration::from_secs(1));
+        assert_eq!(clock.seconds(), 43);
+
+        clock.set_seconds(38);
+        assert_eq!(clock.seconds(), 38);
+
+        sleep(Duration::from_secs(1));
+        assert_eq!(clock.seconds(), 39);
+    }
+}


### PR DESCRIPTION
`naive` rtc implementation was not using is instant, now this PR correct that + add test using a ticking naive