### PR TITLE
Feature/refacto sprite and mem lock

### DIFF
--- a/gb-ppu/examples/objects_viewer.rs
+++ b/gb-ppu/examples/objects_viewer.rs
@@ -2,8 +2,8 @@ use sdl2::{event::Event, keyboard::Keycode};
 
 use gb_lcd::{render, window::GBWindow};
 use gb_ppu::{
-    PPUMem, PPURegisters, OBJECT_LIST_RENDER_HEIGHT, OBJECT_LIST_RENDER_WIDTH,
-    OBJECT_RENDER_HEIGHT, OBJECT_RENDER_WIDTH, PPU,
+    PPUMem, PPURegisters, PPU, SPRITE_LIST_RENDER_HEIGHT, SPRITE_LIST_RENDER_WIDTH,
+    SPRITE_RENDER_HEIGHT, SPRITE_RENDER_WIDTH,
 };
 
 use std::convert::TryInto;
@@ -27,10 +27,10 @@ pub fn main() {
     let bar_pixels_size = GBWindow::dots_to_pixels(&video_subsystem, render::MENU_BAR_SIZE)
         .expect("Error while computing bar size");
     let mut gb_window = GBWindow::new(
-        "Objects",
+        "Sprites",
         (
-            OBJECT_RENDER_WIDTH as u32,
-            OBJECT_RENDER_HEIGHT as u32 + bar_pixels_size,
+            SPRITE_RENDER_WIDTH as u32,
+            SPRITE_RENDER_HEIGHT as u32 + bar_pixels_size,
         ),
         true,
         &video_subsystem,
@@ -44,11 +44,11 @@ pub fn main() {
         .expect("Failed to configure main window");
 
     let mut view_display =
-        render::RenderImage::<OBJECT_RENDER_WIDTH, OBJECT_RENDER_HEIGHT>::with_bar_size(
+        render::RenderImage::<SPRITE_RENDER_WIDTH, SPRITE_RENDER_HEIGHT>::with_bar_size(
             bar_pixels_size as f32,
         );
     let mut list_display =
-        render::RenderImage::<OBJECT_LIST_RENDER_WIDTH, OBJECT_LIST_RENDER_HEIGHT>::with_bar_size(
+        render::RenderImage::<SPRITE_LIST_RENDER_WIDTH, SPRITE_LIST_RENDER_HEIGHT>::with_bar_size(
             bar_pixels_size as f32,
         );
     let ppu = PPU::new();
@@ -76,8 +76,8 @@ pub fn main() {
     ];
     overwrite_memory(&ppu_mem, &ppu_reg, dumps[0]);
     let mut list_mode = false;
-    let mut view_image = ppu.objects_image();
-    let mut list_image = ppu.objects_list_image();
+    let mut view_image = ppu.sprites_image();
+    let mut list_image = ppu.sprites_list_image();
 
     'running: loop {
         gb_window
@@ -91,8 +91,8 @@ pub fn main() {
                     for (title, vram, oam, io_reg) in dumps {
                         if ui.button(title).clicked() {
                             overwrite_memory(&ppu_mem, &ppu_reg, (title, vram, oam, io_reg));
-                            view_image = ppu.objects_image();
-                            list_image = ppu.objects_list_image();
+                            view_image = ppu.sprites_image();
+                            list_image = ppu.sprites_list_image();
                         }
                     }
                 });

--- a/gb-ppu/src/drawing/state.rs
+++ b/gb-ppu/src/drawing/state.rs
@@ -30,6 +30,10 @@ impl State {
         }
     }
 
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
     pub fn update(&mut self, lcd_reg: Option<RefMut<LcdReg>>) {
         match self.mode {
             Mode::HBlank => self.update_hblank(),

--- a/gb-ppu/src/lib.rs
+++ b/gb-ppu/src/lib.rs
@@ -2,9 +2,9 @@ mod color;
 mod drawing;
 mod error;
 mod memory;
-mod object;
 mod ppu;
 mod registers;
+mod sprite;
 
 #[cfg(test)]
 mod test_tools;
@@ -12,6 +12,7 @@ mod test_tools;
 pub use memory::PPUMem;
 pub use ppu::PPU;
 pub use registers::PPURegisters;
+use sprite::Sprite;
 
 pub const TILESHEET_WIDTH: usize = 128;
 pub const TILESHEET_HEIGHT: usize = 192;
@@ -20,12 +21,12 @@ pub const TILESHEET_TILE_COUNT: usize = 16 * 24;
 pub const TILEMAP_DIM: usize = 256;
 pub const TILEMAP_TILE_COUNT: usize = 32 * 32;
 
-pub const OBJECT_RENDER_WIDTH: usize = gb_lcd::render::SCREEN_WIDTH + 16;
-pub const OBJECT_RENDER_HEIGHT: usize = gb_lcd::render::SCREEN_HEIGHT + 32;
+pub const SPRITE_RENDER_WIDTH: usize = gb_lcd::render::SCREEN_WIDTH + 16;
+pub const SPRITE_RENDER_HEIGHT: usize = gb_lcd::render::SCREEN_HEIGHT + 32;
 
-const OBJECT_LIST_PER_LINE: usize = 8;
-pub const OBJECT_LIST_RENDER_WIDTH: usize = OBJECT_LIST_PER_LINE * 8;
-pub const OBJECT_LIST_RENDER_HEIGHT: usize =
-    (memory::Oam::OBJECT_COUNT / OBJECT_LIST_PER_LINE) * 16;
+const SPRITE_LIST_PER_LINE: usize = 8;
+pub const SPRITE_LIST_RENDER_WIDTH: usize = SPRITE_LIST_PER_LINE * 8;
+pub const SPRITE_LIST_RENDER_HEIGHT: usize =
+    (memory::Oam::SPRITE_COUNT / SPRITE_LIST_PER_LINE) * 16;
 
 const UNDEFINED_VALUE: u8 = 0xFF;

--- a/gb-ppu/src/memory.rs
+++ b/gb-ppu/src/memory.rs
@@ -1,7 +1,9 @@
+mod lock;
 mod oam;
 mod ppu_mem;
 mod vram;
 
+pub use lock::{Lock, Lockable};
 pub use oam::Oam;
 pub use ppu_mem::PPUMem;
 pub use vram::Vram;

--- a/gb-ppu/src/memory/lock.rs
+++ b/gb-ppu/src/memory/lock.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, Clone, Copy)]
+pub enum Lock {
+    Ppu,
+    #[allow(dead_code)]
+    Dma,
+}
+
+pub trait Lockable {
+    fn lock(&mut self, owner: Option<Lock>);
+    fn get_lock(&self) -> Option<Lock>;
+}

--- a/gb-ppu/src/memory/oam.rs
+++ b/gb-ppu/src/memory/oam.rs
@@ -1,3 +1,4 @@
+use super::{Lock, Lockable};
 use crate::error::{PPUError, PPUResult};
 use crate::object::Object;
 use std::collections::BTreeMap;
@@ -6,6 +7,7 @@ use std::convert::TryInto;
 /// Contains operations to collect objects from memory.
 pub struct Oam {
     data: [u8; Oam::SIZE as usize],
+    lock: Option<Lock>,
 }
 
 impl Oam {
@@ -15,6 +17,7 @@ impl Oam {
     pub fn new() -> Self {
         Oam {
             data: [0x00; Self::SIZE as usize],
+            lock: None,
         }
     }
 
@@ -99,13 +102,26 @@ impl Default for Oam {
 
 impl From<[u8; Oam::SIZE]> for Oam {
     fn from(bytes: [u8; Oam::SIZE]) -> Oam {
-        Oam { data: bytes }
+        Oam {
+            data: bytes,
+            lock: None,
+        }
     }
 }
 
 impl From<Oam> for [u8; Oam::SIZE] {
     fn from(mem: Oam) -> [u8; Oam::SIZE] {
         mem.data
+    }
+}
+
+impl Lockable for Oam {
+    fn lock(&mut self, owner: Option<Lock>) {
+        self.lock = owner;
+    }
+
+    fn get_lock(&self) -> Option<Lock> {
+        self.lock
     }
 }
 

--- a/gb-ppu/src/memory/ppu_mem.rs
+++ b/gb-ppu/src/memory/ppu_mem.rs
@@ -1,4 +1,4 @@
-use super::{Oam, Vram};
+use super::{Lockable, Oam, Vram};
 use crate::error::{PPUError, PPUResult};
 use crate::UNDEFINED_VALUE;
 use gb_bus::{Address, Area, Error, FileOperation};
@@ -58,19 +58,29 @@ impl FileOperation<Area> for PPUMem {
     /// Read a value from memory. If the concerned memory area is currently locked an undefined value is returned.
     fn read(&self, addr: Box<dyn Address<Area>>) -> Result<u8, Error> {
         match addr.area_type() {
-            Area::Vram => match self.vram.try_borrow() {
-                Ok(vram) => vram
-                    .read(addr.get_address())
-                    .map_err(|_| Error::SegmentationFault(addr.into())),
+            Area::Vram => match self.vram.try_borrow_mut() {
+                Ok(vram) => {
+                    if vram.get_lock().is_none() {
+                        vram.read(addr.get_address())
+                            .map_err(|_| Error::SegmentationFault(addr.into()))
+                    } else {
+                        Ok(UNDEFINED_VALUE)
+                    }
+                }
                 Err(err) => {
                     log::error!("failed vram read: {}", err);
                     Ok(UNDEFINED_VALUE)
                 }
             },
             Area::Oam => match self.oam.try_borrow() {
-                Ok(oam) => oam
-                    .read(addr.get_address())
-                    .map_err(|_| Error::SegmentationFault(addr.into())),
+                Ok(oam) => {
+                    if oam.get_lock().is_none() {
+                        oam.read(addr.get_address())
+                            .map_err(|_| Error::SegmentationFault(addr.into()))
+                    } else {
+                        Ok(UNDEFINED_VALUE)
+                    }
+                }
                 Err(err) => {
                     log::error!("failed oam read: {}", err);
                     Ok(UNDEFINED_VALUE)
@@ -84,18 +94,28 @@ impl FileOperation<Area> for PPUMem {
     fn write(&mut self, v: u8, addr: Box<dyn Address<Area>>) -> Result<(), Error> {
         match addr.area_type() {
             Area::Vram => match self.vram.try_borrow_mut() {
-                Ok(mut vram) => vram
-                    .write(addr.get_address(), v)
-                    .map_err(|_| Error::SegmentationFault(addr.into())),
+                Ok(mut vram) => {
+                    if vram.get_lock().is_none() {
+                        vram.write(addr.get_address(), v)
+                            .map_err(|_| Error::SegmentationFault(addr.into()))
+                    } else {
+                        Ok(())
+                    }
+                }
                 Err(err) => {
                     log::error!("failed vram write: {}", err);
                     Ok(())
                 }
             },
             Area::Oam => match self.oam.try_borrow_mut() {
-                Ok(mut oam) => oam
-                    .write(addr.get_address(), v)
-                    .map_err(|_| Error::SegmentationFault(addr.into())),
+                Ok(mut oam) => {
+                    if oam.get_lock().is_none() {
+                        oam.write(addr.get_address(), v)
+                            .map_err(|_| Error::SegmentationFault(addr.into()))
+                    } else {
+                        Ok(())
+                    }
+                }
                 Err(err) => {
                     log::error!("failed oam write: {}", err);
                     Ok(())

--- a/gb-ppu/src/memory/vram.rs
+++ b/gb-ppu/src/memory/vram.rs
@@ -1,3 +1,4 @@
+use super::{Lock, Lockable};
 use crate::error::{PPUError, PPUResult};
 
 pub const TILEDATA_ADRESS_MAX: usize = 0x17FF;
@@ -9,6 +10,7 @@ pub const TILEDATA_START_1: usize = 0x1000 / 16;
 /// Contains operations to read more easily the differents values of the vram.
 pub struct Vram {
     data: [u8; Vram::SIZE as usize],
+    lock: Option<Lock>,
 }
 
 impl Vram {
@@ -17,6 +19,7 @@ impl Vram {
     pub fn new() -> Self {
         Vram {
             data: [0x00; Self::SIZE as usize],
+            lock: None,
         }
     }
 
@@ -147,13 +150,23 @@ impl Vram {
 
 impl From<[u8; Vram::SIZE]> for Vram {
     fn from(data: [u8; Vram::SIZE]) -> Vram {
-        Vram { data }
+        Vram { data, lock: None }
     }
 }
 
 impl Default for Vram {
     fn default() -> Vram {
         Vram::new()
+    }
+}
+
+impl Lockable for Vram {
+    fn lock(&mut self, owner: Option<Lock>) {
+        self.lock = owner;
+    }
+
+    fn get_lock(&self) -> Option<Lock> {
+        self.lock
     }
 }
 

--- a/gb-ppu/src/ppu.rs
+++ b/gb-ppu/src/ppu.rs
@@ -1,9 +1,10 @@
 use crate::drawing::{Mode, State};
 use crate::memory::{Lock, Lockable, Oam, PPUMem, Vram};
 use crate::registers::{LcdReg, PPURegisters};
+use crate::Sprite;
 use crate::{
-    OBJECT_LIST_PER_LINE, OBJECT_LIST_RENDER_HEIGHT, OBJECT_LIST_RENDER_WIDTH,
-    OBJECT_RENDER_HEIGHT, OBJECT_RENDER_WIDTH, TILEMAP_DIM, TILEMAP_TILE_COUNT, TILESHEET_HEIGHT,
+    SPRITE_LIST_PER_LINE, SPRITE_LIST_RENDER_HEIGHT, SPRITE_LIST_RENDER_WIDTH,
+    SPRITE_RENDER_HEIGHT, SPRITE_RENDER_WIDTH, TILEMAP_DIM, TILEMAP_TILE_COUNT, TILESHEET_HEIGHT,
     TILESHEET_TILE_COUNT, TILESHEET_WIDTH,
 };
 use gb_bus::Bus;
@@ -22,6 +23,7 @@ pub struct PPU {
     lcd_reg: Rc<RefCell<LcdReg>>,
     pixels: RenderData<SCREEN_WIDTH, SCREEN_HEIGHT>,
     state: State,
+    oam_fetched: Vec<Sprite>,
 }
 
 impl PPU {
@@ -32,6 +34,7 @@ impl PPU {
             lcd_reg: Rc::new(RefCell::new(LcdReg::new())),
             pixels: [[[255; 3]; SCREEN_WIDTH]; SCREEN_HEIGHT],
             state: State::new(),
+            oam_fetched: Vec::with_capacity(10),
         }
     }
 
@@ -134,24 +137,24 @@ impl PPU {
         image
     }
 
-    /// Create an image of the currents objects placed relatively to the viewport.
+    /// Create an image of the currents sprites placed relatively to the viewport.
     ///
     /// This function is used for debugging purpose.
-    pub fn objects_image(&self) -> RenderData<OBJECT_RENDER_WIDTH, OBJECT_RENDER_HEIGHT> {
-        let mut image = [[[255; 3]; OBJECT_RENDER_WIDTH]; OBJECT_RENDER_HEIGHT];
-        let objects = self
+    pub fn sprites_image(&self) -> RenderData<SPRITE_RENDER_WIDTH, SPRITE_RENDER_HEIGHT> {
+        let mut image = [[[255; 3]; SPRITE_RENDER_WIDTH]; SPRITE_RENDER_HEIGHT];
+        let sprites = self
             .oam
             .borrow()
-            .collect_all_objects()
-            .expect("failed to collect objects for image");
+            .collect_all_sprites()
+            .expect("failed to collect sprites for image");
         let vram = self.vram.borrow();
         let lcd_reg = self.lcd_reg.borrow();
         let height = if lcd_reg.control.obj_size() { 16 } else { 8 };
-        for object in objects {
-            let x = object.x_pos().min(OBJECT_RENDER_WIDTH as u8 - 8) as usize;
-            let y = object.y_pos().min(OBJECT_RENDER_HEIGHT as u8 - 16) as usize;
+        for sprite in sprites {
+            let x = sprite.x_pos().min(SPRITE_RENDER_WIDTH as u8 - 8) as usize;
+            let y = sprite.y_pos().min(SPRITE_RENDER_HEIGHT as u8 - 16) as usize;
             for j in 0..height {
-                let pixels_values = object
+                let pixels_values = sprite
                     .get_pixels_row(j, &vram, lcd_reg.control.obj_size(), lcd_reg.pal_mono.obj())
                     .expect("invalid line passed");
                 let y_img = y + j;
@@ -166,12 +169,12 @@ impl PPU {
         // draw screen outline
         for (y, column) in image.iter_mut().enumerate() {
             for (x, pixel) in column.iter_mut().enumerate() {
-                if ((x == 7 || x == OBJECT_RENDER_WIDTH - 8)
+                if ((x == 7 || x == SPRITE_RENDER_WIDTH - 8)
                     && y >= 15
-                    && y <= OBJECT_RENDER_HEIGHT - 16)
-                    || ((y == 15 || y == OBJECT_RENDER_HEIGHT - 16)
+                    && y <= SPRITE_RENDER_HEIGHT - 16)
+                    || ((y == 15 || y == SPRITE_RENDER_HEIGHT - 16)
                         && x >= 7
-                        && x <= OBJECT_RENDER_WIDTH - 8)
+                        && x <= SPRITE_RENDER_WIDTH - 8)
                 {
                     *pixel = [!pixel[0], !pixel[1], !pixel[2]];
                 }
@@ -180,26 +183,26 @@ impl PPU {
         image
     }
 
-    /// Create an image of the currents objects.
+    /// Create an image of the currents sprites.
     ///
     /// This function is used for debugging purpose.
-    pub fn objects_list_image(
+    pub fn sprites_list_image(
         &self,
-    ) -> RenderData<OBJECT_LIST_RENDER_WIDTH, OBJECT_LIST_RENDER_HEIGHT> {
-        let mut image = [[[255; 3]; OBJECT_LIST_RENDER_WIDTH]; OBJECT_LIST_RENDER_HEIGHT];
-        let objects = self
+    ) -> RenderData<SPRITE_LIST_RENDER_WIDTH, SPRITE_LIST_RENDER_HEIGHT> {
+        let mut image = [[[255; 3]; SPRITE_LIST_RENDER_WIDTH]; SPRITE_LIST_RENDER_HEIGHT];
+        let sprites = self
             .oam
             .borrow()
-            .collect_all_objects()
-            .expect("failed to collect objects for image");
+            .collect_all_sprites()
+            .expect("failed to collect sprites for image");
         let vram = self.vram.borrow();
         let lcd_reg = self.lcd_reg.borrow();
         let height = if lcd_reg.control.obj_size() { 16 } else { 8 };
-        for (r, object) in objects.iter().enumerate() {
-            let x = (r % OBJECT_LIST_PER_LINE) * 8;
-            let y = (r / OBJECT_LIST_PER_LINE) * 16;
+        for (r, sprite) in sprites.iter().enumerate() {
+            let x = (r % SPRITE_LIST_PER_LINE) * 8;
+            let y = (r / SPRITE_LIST_PER_LINE) * 16;
             for j in 0..height {
-                let pixels_values = object
+                let pixels_values = sprite
                     .get_pixels_row(j, &vram, lcd_reg.control.obj_size(), lcd_reg.pal_mono.obj())
                     .expect("invalid line passed");
                 let y_img = y + j;

--- a/gb-ppu/src/sprite.rs
+++ b/gb-ppu/src/sprite.rs
@@ -22,16 +22,16 @@ struct Attributes {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Object {
+pub struct Sprite {
     y_pos: u8,
     x_pos: u8,
     tile_index: u8,
     attributes: Attributes,
 }
 
-impl Object {
+impl Sprite {
     pub fn new() -> Self {
-        Object {
+        Sprite {
             y_pos: 0,
             x_pos: 0,
             tile_index: 0,
@@ -57,12 +57,12 @@ impl Object {
         self.attributes.x_flip() != 0
     }
 
-    /// Read the row of 8 pixels values for this object.
+    /// Read the row of 8 pixels values for this sprite.
     ///
     /// ### Parameters
     ///  - **line**: The index of the row of pixel to return. Should be below 8 or 16 depending of the size_16 flag.
     ///  - **vram**: A reference to the vram to read the pixel values from.
-    ///  - **size_16**: the bit 2 flag from Control indicating if the object is 8(*false*) or 16(*true*) pixels high.
+    ///  - **size_16**: the bit 2 flag from Control indicating if the sprite is 8(*false*) or 16(*true*) pixels high.
     pub fn get_pixels_row(
         &self,
         line: usize,
@@ -82,7 +82,7 @@ impl Object {
         }
     }
 
-    /// Read the row of 8 pixels values for this object in 8x8 pixels mode.
+    /// Read the row of 8 pixels values for this sprite in 8x8 pixels mode.
     ///
     /// ### Parameters
     ///  - **line**: The index of the row of pixel to return. Should be below 8.
@@ -112,7 +112,7 @@ impl Object {
         Ok(row)
     }
 
-    /// Read the row of 8 pixels values for this object in 8x16 pixels mode.
+    /// Read the row of 8 pixels values for this sprite in 8x16 pixels mode.
     ///
     /// ### Parameters
     ///  - **line**: The index of the row of pixel to return. Should be below 16.
@@ -151,9 +151,9 @@ impl Object {
     }
 }
 
-impl From<[u8; Object::SIZE]> for Object {
-    fn from(bytes: [u8; Object::SIZE]) -> Object {
-        Object {
+impl From<[u8; Sprite::SIZE]> for Sprite {
+    fn from(bytes: [u8; Sprite::SIZE]) -> Sprite {
+        Sprite {
             y_pos: bytes[0],
             x_pos: bytes[1],
             tile_index: bytes[2],
@@ -162,8 +162,8 @@ impl From<[u8; Object::SIZE]> for Object {
     }
 }
 
-impl From<Object> for [u8; Object::SIZE] {
-    fn from(obj: Object) -> [u8; Object::SIZE] {
+impl From<Sprite> for [u8; Sprite::SIZE] {
+    fn from(obj: Sprite) -> [u8; Sprite::SIZE] {
         [
             obj.y_pos,
             obj.x_pos,


### PR DESCRIPTION
- Rename struct `Object` into `Sprite` to be more explicit.
- Change how the memory area of the ppu are locked, potentially allowing external structure to do the same.