### PR TITLE
Feature/implement `wram`, `eram`, `hram`

### DIFF
--- a/gb-bus/src/generic.rs
+++ b/gb-bus/src/generic.rs
@@ -1,5 +1,7 @@
 mod chardev;
 mod random;
+mod simple;
 
 pub use chardev::CharDevice;
 pub use random::RandomDevice;
+pub use simple::SimpleRW;

--- a/gb-bus/src/generic/simple.rs
+++ b/gb-bus/src/generic/simple.rs
@@ -1,0 +1,22 @@
+use crate::{
+    area::Area,
+    error::Error,
+    file_operation::{Address, FileOperation},
+};
+
+pub struct SimpleRW<const SIZE: usize> {
+    store: [u8; SIZE],
+}
+
+impl<const SIZE: usize> FileOperation<Area> for SimpleRW<SIZE> {
+    fn write(&mut self, v: u8, addr: Box<dyn Address<Area>>) -> Result<(), Error> {
+        let address = addr.get_address();
+        self.store[address] = v;
+        Ok(())
+    }
+
+    fn read(&self, addr: Box<dyn Address<Area>>) -> Result<u8, Error> {
+        let address = addr.get_address();
+        Ok(self.store[address])
+    }
+}

--- a/gb-bus/src/lib.rs
+++ b/gb-bus/src/lib.rs
@@ -15,7 +15,7 @@ pub use area::Area;
 pub use error::Error;
 pub use file_operation::{Address, FileOperation};
 pub use io_reg_area::IORegArea;
-pub use working_ram::WRam;
+pub use working_ram::WorkingRam;
 
 pub trait Bus<N> {
     /// read `N` into the bus

--- a/gb-bus/src/lib.rs
+++ b/gb-bus/src/lib.rs
@@ -8,12 +8,14 @@ pub mod generic;
 pub mod io_reg_area;
 mod io_reg_bus;
 pub mod io_reg_constant;
+mod working_ram;
 
 pub use address_bus::AddressBus;
 pub use area::Area;
 pub use error::Error;
 pub use file_operation::{Address, FileOperation};
 pub use io_reg_area::IORegArea;
+pub use working_ram::WRam;
 
 pub trait Bus<N> {
     /// read `N` into the bus

--- a/gb-bus/src/working_ram.rs
+++ b/gb-bus/src/working_ram.rs
@@ -1,0 +1,82 @@
+use crate::{Address, Area, Error, FileOperation, IORegArea};
+
+pub const RAM_BANK_SIZE: usize = 0x1000;
+pub const CGB_MAX_BANKS: usize = 8;
+pub const DMG_MAX_BANKS: usize = 2;
+
+pub struct WorkingRam {
+    banks: Vec<[u8; RAM_BANK_SIZE]>,
+    selected_bank: u8,
+    enable_cbg_feature: bool,
+}
+
+impl WorkingRam {
+    pub fn new(enable_cbg_feature: bool) -> Self {
+        let banks = if enable_cbg_feature {
+            Vec::with_capacity(CGB_MAX_BANKS)
+        } else {
+            Vec::with_capacity(DMG_MAX_BANKS)
+        };
+        Self {
+            banks,
+            enable_cbg_feature,
+            selected_bank: 1,
+        }
+    }
+}
+
+impl FileOperation<Area> for WorkingRam {
+    fn write(&mut self, value: u8, addr: Box<dyn Address<Area>>) -> Result<(), Error> {
+        let address = addr.get_address();
+        match address {
+            0..=0xfff => self.banks[0][address] = value,
+            0x1000..=0x1fff => {
+                let address = address - 0x1000;
+                let index = if self.enable_cbg_feature {
+                    self.selected_bank as usize
+                } else {
+                    1
+                };
+                self.banks[index][address] = value;
+            }
+            _ => return Err(Error::new_bus_error(addr)),
+        }
+        Ok(())
+    }
+
+    fn read(&self, addr: Box<dyn Address<Area>>) -> Result<u8, Error> {
+        let address = addr.get_address();
+        match address {
+            0..=0xfff => Ok(self.banks[0][address]),
+            0x1000..=0x1fff => {
+                let address = address - 0x1000;
+                let index = if self.enable_cbg_feature {
+                    self.selected_bank as usize
+                } else {
+                    1
+                };
+                Ok(self.banks[index][address])
+            }
+            _ => Err(Error::new_bus_error(addr)),
+        }
+    }
+}
+
+impl FileOperation<IORegArea> for WorkingRam {
+    fn write(&mut self, value: u8, addr: Box<dyn Address<IORegArea>>) -> Result<(), Error> {
+        if self.enable_cbg_feature {
+            self.selected_bank = value.clamp(1, 7);
+            Ok(())
+        } else {
+            Err(Error::new_segfault(addr))
+        }
+    }
+
+    fn read(&self, addr: Box<dyn Address<IORegArea>>) -> Result<u8, Error> {
+        if self.enable_cbg_feature {
+            Ok(self.selected_bank)
+        } else {
+            Err(Error::new_segfault(addr))
+        }
+    }
+}

--- a/gb-bus/src/working_ram.rs
+++ b/gb-bus/src/working_ram.rs
@@ -7,19 +7,19 @@ pub const DMG_MAX_BANKS: usize = 2;
 pub struct WorkingRam {
     banks: Vec<[u8; RAM_BANK_SIZE]>,
     selected_bank: u8,
-    enable_cbg_feature: bool,
+    enable_cgb_feature: bool,
 }
 
 impl WorkingRam {
-    pub fn new(enable_cbg_feature: bool) -> Self {
-        let banks = if enable_cbg_feature {
+    pub fn new(enable_cgb_feature: bool) -> Self {
+        let banks = if enable_cgb_feature {
             Vec::with_capacity(CGB_MAX_BANKS)
         } else {
             Vec::with_capacity(DMG_MAX_BANKS)
         };
         Self {
             banks,
-            enable_cbg_feature,
+            enable_cgb_feature,
             selected_bank: 1,
         }
     }
@@ -32,7 +32,7 @@ impl FileOperation<Area> for WorkingRam {
             0..=0xfff => self.banks[0][address] = value,
             0x1000..=0x1fff => {
                 let address = address - 0x1000;
-                let index = if self.enable_cbg_feature {
+                let index = if self.enable_cgb_feature {
                     self.selected_bank as usize
                 } else {
                     1
@@ -50,7 +50,7 @@ impl FileOperation<Area> for WorkingRam {
             0..=0xfff => Ok(self.banks[0][address]),
             0x1000..=0x1fff => {
                 let address = address - 0x1000;
-                let index = if self.enable_cbg_feature {
+                let index = if self.enable_cgb_feature {
                     self.selected_bank as usize
                 } else {
                     1
@@ -64,7 +64,7 @@ impl FileOperation<Area> for WorkingRam {
 
 impl FileOperation<IORegArea> for WorkingRam {
     fn write(&mut self, value: u8, addr: Box<dyn Address<IORegArea>>) -> Result<(), Error> {
-        if self.enable_cbg_feature {
+        if self.enable_cgb_feature {
             self.selected_bank = value.clamp(1, 7);
             Ok(())
         } else {
@@ -73,7 +73,7 @@ impl FileOperation<IORegArea> for WorkingRam {
     }
 
     fn read(&self, addr: Box<dyn Address<IORegArea>>) -> Result<u8, Error> {
-        if self.enable_cbg_feature {
+        if self.enable_cgb_feature {
             Ok(self.selected_bank)
         } else {
             Err(Error::new_segfault(addr))


### PR DESCRIPTION
- implement `Working ram` for the bus
- since `echo ram` is a copy of `working ram` the same instance can be reused for `eram`
- `hram` can be implemented by using `SimpleRW`

closes #223, closes #219 close #225