### PR TITLE
Implement Arithmetic Logic Unit opcode (not needed in `DMG Bios`)

### DIFF
--- a/gb-cpu/src/microcode/fetch.rs
+++ b/gb-cpu/src/microcode/fetch.rs
@@ -437,6 +437,8 @@ pub fn fetch(ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow 
                 Opcode::Rra => ctl.push_actions(&[read::a, bitwise::rr, write::a]),
                 Opcode::RlcA => ctl.push_actions(&[read::a, bitwise::rlc, write::a]),
 
+                Opcode::Scf => ctl.push_actions(&[logic::scf]),
+
                 Opcode::Nop => &mut ctl,
                 Opcode::PrefixCb => ctl.push_action(fetch_cb),
                 _ => todo!("unimplemented opcode {:?}", opcode),

--- a/gb-cpu/src/microcode/logic.rs
+++ b/gb-cpu/src/microcode/logic.rs
@@ -19,3 +19,10 @@ pub fn xor(ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow {
     ctl.push(value);
     OK_PLAY_NEXT_ACTION
 }
+
+pub fn scf(_ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow {
+    state.regs.set_carry(true);
+    state.regs.set_half_carry(false);
+    state.regs.set_subtraction(false);
+    OK_PLAY_NEXT_ACTION
+}


### PR DESCRIPTION
- [ ] #228
- [ ] `CPL`
- [ ] `CCF`
- [ ] `Adc`
- [ ] `Sbc`
- [ ] `And`
- [ ] `Or`