### PR TITLE
Bufix/debug ppu rendering

### DIFF
--- a/gb-ppu/src/drawing/pixel_fetcher.rs
+++ b/gb-ppu/src/drawing/pixel_fetcher.rs
@@ -6,7 +6,7 @@ use gb_lcd::render::{SCREEN_HEIGHT, SCREEN_WIDTH};
 use std::collections::VecDeque;
 use std::ops::Deref;
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Clone, Copy)]
 pub enum FetchMode {
     Background,
     Window,
@@ -21,7 +21,7 @@ impl Default for FetchMode {
 
 pub struct PixelFetcher {
     pixels: VecDeque<Pixel>,
-    pub mode: FetchMode,
+    mode: FetchMode,
     internal_tick: u8,
     tile: usize,
 }
@@ -48,6 +48,10 @@ impl PixelFetcher {
             self.pixels.clear();
         }
         self.mode = mode;
+    }
+
+    pub fn mode(&self) -> FetchMode {
+        self.mode
     }
 
     pub fn fetch(

--- a/gb-ppu/src/ppu.rs
+++ b/gb-ppu/src/ppu.rs
@@ -376,11 +376,14 @@ impl Ppu {
         let (x, y) = cursor;
 
         if lcd_reg.window_pos.wy <= y && lcd_reg.window_pos.wx <= x {
-            pixel_fetcher.set_mode(FetchMode::Window);
-        } else {
+            if pixel_fetcher.mode() == FetchMode::Background {
+                pixel_fetcher.set_mode(FetchMode::Window);
+                pixel_fifo.clear();
+            }
+        } else if pixel_fetcher.mode() == FetchMode::Window {
             pixel_fetcher.set_mode(FetchMode::Background);
+            pixel_fifo.clear();
         }
-        pixel_fifo.clear();
     }
 
     fn check_for_sprite_mode(

--- a/gb-ppu/src/ppu.rs
+++ b/gb-ppu/src/ppu.rs
@@ -234,66 +234,86 @@ impl Ppu {
     }
 
     fn hblank<B: Bus<u8>>(&mut self, adr_bus: &mut B) {
+        let unlock_oam: bool;
         if let Ok(oam) = self.oam.try_borrow() {
             if let Some(Lock::Ppu) = oam.get_lock() {
-                adr_bus.unlock(Area::Oam);
+                unlock_oam = true;
+            } else {
+                unlock_oam = false;
             }
         } else {
             log::error!("Oam borrow failed for ppu in mode 0");
+            unlock_oam = false;
         }
+        if unlock_oam {
+            adr_bus.unlock(Area::Oam);
+        }
+
+        let unlock_vram: bool;
         if let Ok(vram) = self.vram.try_borrow() {
             if let Some(Lock::Ppu) = vram.get_lock() {
-                adr_bus.unlock(Area::Vram);
+                unlock_vram = true;
+            } else {
+                unlock_vram = false;
             }
         } else {
             log::error!("Vram borrow failed for ppu in mode 0");
+            unlock_vram = false;
+        }
+        if unlock_vram {
+            adr_bus.unlock(Area::Vram);
         }
     }
 
     fn oam_fetch<B: Bus<u8>>(&mut self, adr_bus: &mut B) {
         if let Ok(lcd_reg) = self.lcd_reg.try_borrow() {
+            let mut lock: Option<Lock>;
+            let step: u16;
             if let Ok(oam) = self.oam.try_borrow() {
-                let lock = oam.get_lock();
-                let step = self.state.step();
+                lock = oam.get_lock();
+                step = self.state.step();
+            } else {
+                log::error!("Oam borrow failed for ppu in mode 2");
+                return;
+            }
 
-                if lock.is_none() {
-                    // init mode 2
-                    adr_bus.lock(Area::Oam, Lock::Ppu);
-                    self.scanline_sprites.clear();
-                }
-                if let Some(Lock::Ppu) = lock {
-                    if step % 2 == 1 {
-                        let sprite_pos = step as usize / 2;
+            if lock.is_none() {
+                // init mode 2
+                adr_bus.lock(Area::Oam, Lock::Ppu);
+                lock = Some(Lock::Ppu);
+                self.scanline_sprites.clear();
+            }
+            if let Some(Lock::Ppu) = lock {
+                let oam = self.oam.borrow();
+                if step % 2 == 1 {
+                    let sprite_pos = step as usize / 2;
 
-                        match oam.read_sprite(sprite_pos) {
-                            Err(err) => log::error!("Error while reading sprite: {}", err),
-                            Ok(sprite) => {
-                                let scanline = self.state.line() + 16;
-                                let top = sprite.y_pos();
-                                let bot = top + if lcd_reg.control.obj_size() { 16 } else { 8 };
+                    match oam.read_sprite(sprite_pos) {
+                        Err(err) => log::error!("Error while reading sprite: {}", err),
+                        Ok(sprite) => {
+                            let scanline = self.state.line() + 16;
+                            let top = sprite.y_pos();
+                            let bot = top + if lcd_reg.control.obj_size() { 16 } else { 8 };
 
-                                if scanline >= top && scanline < bot {
-                                    for i in 0..self.scanline_sprites.len() {
-                                        let scan_sprite = self.scanline_sprites[i];
+                            if scanline >= top && scanline < bot {
+                                for i in 0..self.scanline_sprites.len() {
+                                    let scan_sprite = self.scanline_sprites[i];
 
-                                        if sprite.x_pos() < scan_sprite.x_pos() {
-                                            self.scanline_sprites.insert(i, sprite);
-                                            if self.scanline_sprites.len() > 10 {
-                                                self.scanline_sprites.pop();
-                                            }
-                                            return;
+                                    if sprite.x_pos() < scan_sprite.x_pos() {
+                                        self.scanline_sprites.insert(i, sprite);
+                                        if self.scanline_sprites.len() > 10 {
+                                            self.scanline_sprites.pop();
                                         }
+                                        return;
                                     }
-                                    if self.scanline_sprites.len() < 10 {
-                                        self.scanline_sprites.push(sprite);
-                                    }
+                                }
+                                if self.scanline_sprites.len() < 10 {
+                                    self.scanline_sprites.push(sprite);
                                 }
                             }
                         }
                     }
                 }
-            } else {
-                log::error!("Oam borrow failed for ppu in mode 2");
             }
         } else {
             log::error!("Lcd reg borrow failed for ppu in mode 2");
@@ -302,19 +322,49 @@ impl Ppu {
 
     fn pixel_drawing<B: Bus<u8>>(&mut self, adr_bus: &mut B) {
         if let Ok(lcd_reg) = self.lcd_reg.try_borrow() {
+            let mut lock: Option<Lock>;
+            let x: u8;
+            let y: u8;
             if let Ok(vram) = self.vram.try_borrow() {
-                let lock = vram.get_lock();
-                let x = self.state.pixel_drawn();
-                let y = self.state.line();
+                lock = vram.get_lock();
+                x = self.state.pixel_drawn();
+                y = self.state.line();
+            } else {
+                log::error!("Vram borrow failed for ppu in mode 3");
+                return;
+            }
 
-                if lock.is_none() {
-                    // init mode 3
-                    adr_bus.lock(Area::Vram, Lock::Ppu);
-                    self.pixel_fetcher.clear();
-                    self.pixel_fifo.clear();
-                    self.state.clear_pixel_count();
-                    // reverse the sprites order so the ones on the left of the viewport are the first to pop
-                    self.scanline_sprites = self.scanline_sprites.drain(0..).rev().collect();
+            if lock.is_none() {
+                // init mode 3
+                adr_bus.lock(Area::Vram, Lock::Ppu);
+                lock = Some(Lock::Ppu);
+                self.pixel_fetcher.clear();
+                self.pixel_fifo.clear();
+                self.state.clear_pixel_count();
+                // reverse the sprites order so the ones on the left of the viewport are the first to pop
+                self.scanline_sprites = self.scanline_sprites.drain(0..).rev().collect();
+                Self::check_next_pixel_mode(
+                    &lcd_reg,
+                    &mut self.pixel_fetcher,
+                    &mut self.pixel_fifo,
+                    &mut self.scanline_sprites,
+                    (x, y),
+                );
+            }
+            if let Some(Lock::Ppu) = lock {
+                let vram = self.vram.borrow();
+                if self.pixel_fifo.enabled && x < SCREEN_WIDTH as u8 {
+                    if let Some(pixel) = self.pixel_fifo.pop() {
+                        self.next_pixels[y as usize][x as usize] = Color::from(pixel).into();
+                        self.state.draw_pixel();
+                    };
+                }
+                self.pixel_fetcher
+                    .fetch(&vram, &lcd_reg, y as usize, x as usize);
+                self.pixel_fetcher.push_to_fifo(&mut self.pixel_fifo);
+                if self.pixel_fetcher.push_to_fifo(&mut self.pixel_fifo)
+                    || x < self.state.pixel_drawn()
+                {
                     Self::check_next_pixel_mode(
                         &lcd_reg,
                         &mut self.pixel_fetcher,
@@ -323,30 +373,6 @@ impl Ppu {
                         (x, y),
                     );
                 }
-                if let Some(Lock::Ppu) = lock {
-                    if self.pixel_fifo.enabled && x < SCREEN_WIDTH as u8 {
-                        if let Some(pixel) = self.pixel_fifo.pop() {
-                            self.next_pixels[y as usize][x as usize] = Color::from(pixel).into();
-                            self.state.draw_pixel();
-                        };
-                    }
-                    self.pixel_fetcher
-                        .fetch(&vram, &lcd_reg, y as usize, x as usize);
-                    self.pixel_fetcher.push_to_fifo(&mut self.pixel_fifo);
-                    if self.pixel_fetcher.push_to_fifo(&mut self.pixel_fifo)
-                        || x < self.state.pixel_drawn()
-                    {
-                        Self::check_next_pixel_mode(
-                            &lcd_reg,
-                            &mut self.pixel_fetcher,
-                            &mut self.pixel_fifo,
-                            &mut self.scanline_sprites,
-                            (x, y),
-                        );
-                    }
-                }
-            } else {
-                log::error!("Vram borrow failed for ppu in mode 3");
             }
         } else {
             log::error!("Lcd_reg borrow failed for ppu in mode 3");

--- a/gb-ppu/src/registers/ppu_registers.rs
+++ b/gb-ppu/src/registers/ppu_registers.rs
@@ -64,7 +64,6 @@ impl FileOperation<IORegArea> for PPURegisters {
     }
 
     fn write(&mut self, v: u8, addr: Box<dyn Address<IORegArea>>) -> Result<(), Error> {
-        log::warn!("missing ppu registers write");
         match addr.area_type() {
             IORegArea::Lcd => match self.lcd.try_borrow_mut() {
                 Ok(mut lcd) => lcd.write(addr, v),

--- a/gb-ppu/src/registers/ppu_registers.rs
+++ b/gb-ppu/src/registers/ppu_registers.rs
@@ -38,7 +38,6 @@ impl PPURegisters {
 
 impl FileOperation<IORegArea> for PPURegisters {
     fn read(&self, addr: Box<dyn Address<IORegArea>>) -> Result<u8, Error> {
-        log::warn!("missing ppu registers read");
         match addr.area_type() {
             IORegArea::Lcd => match self.lcd.try_borrow() {
                 Ok(lcd) => lcd.read(addr),


### PR DESCRIPTION
Debug rendering not drawing enough pixels per line.
Avoid double borrow of vram/oam by the ppu and the bus at the same time when locking/unlocking.

depends on #282 