### PR TITLE
Feature/put trace bus log behing features

### DIFF
--- a/gb-bus/Cargo.toml
+++ b/gb-bus/Cargo.toml
@@ -8,3 +8,8 @@ edition = "2021"
 [dependencies]
 rand = { version = "0.8.4", features = ["small_rng"] }
 log = "0.4"
+
+[features]
+trace_bus_full = ["trace_bus_write", "trace_bus_read"]
+trace_bus_write = []
+trace_bus_read = []

--- a/gb-bus/src/address_bus.rs
+++ b/gb-bus/src/address_bus.rs
@@ -18,6 +18,7 @@ use std::{cell::RefCell, rc::Rc};
 
 macro_rules! write_area {
     ($start:expr, $field:expr, $area_type:ident, $value:expr, $addr:expr) => {{
+        #[cfg(features = "trace_bus_write")]
         log::trace!(
             "writing at {:4x} the value {:2x} in area {:?}",
             $addr,
@@ -33,6 +34,7 @@ macro_rules! write_area {
 
 macro_rules! read_area {
     ($start:expr, $field:expr, $area_type:ident, $addr: expr) => {{
+        #[cfg(features = "trace_bus_read")]
         log::trace!("reading at {:4x} in area {:?}", $addr, Area::$area_type);
         $field.borrow().read(Box::new(Address::from_offset(
             Area::$area_type,

--- a/gb-bus/src/io_reg_bus.rs
+++ b/gb-bus/src/io_reg_bus.rs
@@ -13,6 +13,7 @@ use std::{cell::RefCell, rc::Rc};
 
 macro_rules! write_area {
     ($start:expr, $field:expr, $area_type:ident, $value:expr, $addr:expr) => {{
+        #[cfg(features = "trace_bus_write")]
         log::trace!(
             "writing at {:4x} the value {:2x} in area {:?}",
             $addr,
@@ -28,6 +29,7 @@ macro_rules! write_area {
 
 macro_rules! read_area {
     ($start:expr, $field:expr, $area_type:ident, $addr: expr) => {{
+        #[cfg(features = "trace_bus_rea")]
         log::trace!(
             "reading at {:4x} in area {:?}",
             $addr,


### PR DESCRIPTION
put write/read trace log of the bus address behind a feature to reduce the amount of data outputted in trace log level