### PR TITLE
Feature/impl dbg reg refactor

### DIFF
--- a/.idea/GBMU.iml
+++ b/.idea/GBMU.iml
@@ -16,6 +16,11 @@
       <sourceFolder url="file://$MODULE_DIR$/gb-clock/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/gb-joypad/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/gb-rtc/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/gb-cpu/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/gb-cpu/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/gb-dma/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/gb-test/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/gb-timer/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/gb-dbg/examples/debug_eframe/game.rs
+++ b/gb-dbg/examples/debug_eframe/game.rs
@@ -1,6 +1,6 @@
 use gb_dbg::dbg_interfaces::{
-    CpuRegs, DebugOperations, IORegs, MemoryDebugOperations, PpuRegs, RegisterDebugOperations,
-    RegisterMap, RegisterValue,
+    AudioRegs, CpuRegs, DebugOperations, IORegs, MemoryDebugOperations, PpuRegs,
+    RegisterDebugOperations, RegisterMap, RegisterValue,
 };
 
 pub struct Iter<'a> {
@@ -121,15 +121,70 @@ impl RegisterDebugOperations for Game {
         Ok(0xffu8.into())
     }
 
+    fn audio_get(&self, _key: AudioRegs) -> anyhow::Result<RegisterValue> {
+        Ok(0xffu8.into())
+    }
+
     fn cpu_registers(&self) -> Vec<RegisterMap<CpuRegs>> {
         self.into()
     }
 
     fn ppu_registers(&self) -> Vec<RegisterMap<PpuRegs>> {
-        Vec::new()
+        vec![
+            RegisterMap(PpuRegs::Control, RegisterValue::from(2u8)),
+            RegisterMap(PpuRegs::Status, RegisterValue::from(14u8)),
+            RegisterMap(PpuRegs::Scy, RegisterValue::from(34u8)),
+            RegisterMap(PpuRegs::Scx, RegisterValue::from(125u16)),
+            RegisterMap(PpuRegs::Ly, RegisterValue::from(28u8)),
+            RegisterMap(PpuRegs::Lyc, RegisterValue::from(556u16)),
+            RegisterMap(PpuRegs::Dma, RegisterValue::from(444u16)),
+            RegisterMap(PpuRegs::Bgp, RegisterValue::from(215u8)),
+            RegisterMap(PpuRegs::Obp0, RegisterValue::from(33u8)),
+            RegisterMap(PpuRegs::Obp1, RegisterValue::from(8u8)),
+            RegisterMap(PpuRegs::Wy, RegisterValue::from(6u8)),
+            RegisterMap(PpuRegs::Wx, RegisterValue::from(88u8)),
+        ]
     }
 
     fn io_registers(&self) -> Vec<RegisterMap<IORegs>> {
-        Vec::new()
+        vec![
+            RegisterMap(IORegs::Joy, RegisterValue::from(2u8)),
+            RegisterMap(IORegs::SerialByte, RegisterValue::from(14u8)),
+            RegisterMap(IORegs::SerialCtl, RegisterValue::from(34u8)),
+            RegisterMap(IORegs::Div, RegisterValue::from(125u16)),
+            RegisterMap(IORegs::Tima, RegisterValue::from(28u8)),
+            RegisterMap(IORegs::Tma, RegisterValue::from(556u16)),
+            RegisterMap(IORegs::Tac, RegisterValue::from(444u16)),
+            RegisterMap(IORegs::If, RegisterValue::from(215u8)),
+            RegisterMap(IORegs::Ie, RegisterValue::from(33u8)),
+            RegisterMap(IORegs::BootRom, RegisterValue::from(81u16)),
+        ]
+    }
+
+    fn audio_registers(&self) -> Vec<RegisterMap<AudioRegs>> {
+        vec![
+            RegisterMap(AudioRegs::Fs1, RegisterValue::from(22u8)),
+            RegisterMap(AudioRegs::Pwm1, RegisterValue::from(2u8)),
+            RegisterMap(AudioRegs::Env1, RegisterValue::from(14u8)),
+            RegisterMap(AudioRegs::Af1, RegisterValue::from(34u8)),
+            RegisterMap(AudioRegs::Ctl1, RegisterValue::from(125u16)),
+            RegisterMap(AudioRegs::Pwm2, RegisterValue::from(288u16)),
+            RegisterMap(AudioRegs::Env2, RegisterValue::from(555u16)),
+            RegisterMap(AudioRegs::Af2, RegisterValue::from(444u16)),
+            RegisterMap(AudioRegs::Ctl2, RegisterValue::from(215u8)),
+            RegisterMap(AudioRegs::A3Toggle, RegisterValue::from(33u8)),
+            RegisterMap(AudioRegs::Pwm3, RegisterValue::from(81u16)),
+            RegisterMap(AudioRegs::Vol3, RegisterValue::from(48u16)),
+            RegisterMap(AudioRegs::Af3, RegisterValue::from(8u16)),
+            RegisterMap(AudioRegs::Ctl3, RegisterValue::from(99u16)),
+            RegisterMap(AudioRegs::Pwm4, RegisterValue::from(269u16)),
+            RegisterMap(AudioRegs::Vol4, RegisterValue::from(8654u16)),
+            RegisterMap(AudioRegs::Af4, RegisterValue::from(69u16)),
+            RegisterMap(AudioRegs::Ctl4, RegisterValue::from(6u16)),
+            RegisterMap(AudioRegs::AudOutMap, RegisterValue::from(15042u16)),
+            RegisterMap(AudioRegs::AudMap, RegisterValue::from(5555u16)),
+            RegisterMap(AudioRegs::AudChanCtl, RegisterValue::from(251u8)),
+            RegisterMap(AudioRegs::AudWave, RegisterValue::from(12u8)),
+        ]
     }
 }

--- a/gb-dbg/examples/debug_eframe/main.rs
+++ b/gb-dbg/examples/debug_eframe/main.rs
@@ -43,7 +43,7 @@ fn main() {
     };
     let options = NativeOptions {
         resizable: false,
-        initial_window_size: Some(Vec2::new(1000.0, 600.0)),
+        initial_window_size: Some(Vec2::new(1200.0, 600.0)),
         ..Default::default()
     };
     eframe::run_native(Box::new(dgb_app), options)

--- a/gb-dbg/src/dbg_interfaces.rs
+++ b/gb-dbg/src/dbg_interfaces.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 
-pub struct RegisterMap<T: Display>(pub T, pub RegisterValue);
+pub struct RegisterMap<T: Display + Debug>(pub T, pub RegisterValue);
 
 #[derive(Clone, Copy)]
 pub enum RegisterValue {
@@ -54,6 +54,7 @@ pub trait RegisterDebugOperations {
     fn audio_registers(&self) -> Vec<RegisterMap<AudioRegs>>;
 }
 
+#[derive(Debug)]
 pub enum CpuRegs {
     AF,
     BC,
@@ -77,6 +78,7 @@ impl Display for CpuRegs {
     }
 }
 
+#[derive(Debug)]
 pub enum PpuRegs {
     Control,
     Status,
@@ -112,11 +114,12 @@ impl Display for PpuRegs {
     }
 }
 
+#[derive(Debug)]
 pub enum IORegs {
     Joy,
 
     SerialByte,
-    SerialControl,
+    SerialCtl,
 
     Div,
     Tima,
@@ -134,7 +137,7 @@ impl Display for IORegs {
         let name = match self {
             IORegs::Joy => "Joypad",
             IORegs::SerialByte => "Serial Byte",
-            IORegs::SerialControl => "Serial Control",
+            IORegs::SerialCtl => "Serial Control",
             IORegs::Div => "Div",
             IORegs::Tima => "Tima",
             IORegs::Tma => "Tma",
@@ -147,6 +150,7 @@ impl Display for IORegs {
     }
 }
 
+#[derive(Debug)]
 pub enum AudioRegs {
     Fs1,
     Pwm1,
@@ -179,30 +183,29 @@ pub enum AudioRegs {
 impl Display for AudioRegs {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let name = match self {
-            AudioRegs::Fs1 => "Aud 1 Sweep",
-            AudioRegs::Pwm1 => "Aud 1 Wave Duty",
-            AudioRegs::Env1 => "Aud 1 Envelope",
-            AudioRegs::Af1 => "Aud 1 Freq",
-            AudioRegs::Ctl1 => "Aud 1 Ctl",
-            AudioRegs::Pwm2 => "Aud 2 Wave Duty",
-            AudioRegs::Env2 => "Aud 2 Envelope",
-            AudioRegs::Af2 => "Aud 2 Freq",
-            AudioRegs::Ctl2 => "Aud 2 Ctl",
+            AudioRegs::Fs1 => "Audio 1 Sweep",
+            AudioRegs::Pwm1 => "Audio 1 Wave Duty",
+            AudioRegs::Env1 => "Audio 1 Envelope",
+            AudioRegs::Af1 => "Audio 1 Freq",
+            AudioRegs::Ctl1 => "Audio 1 Ctl",
+            AudioRegs::Pwm2 => "Audio 2 Wave Duty",
+            AudioRegs::Env2 => "Audio 2 Envelope",
+            AudioRegs::Af2 => "Audio 2 Freq",
+            AudioRegs::Ctl2 => "Audio 2 Ctl",
             AudioRegs::A3Toggle => "Audio Channel 3 Toggle",
-            AudioRegs::Pwm3 => "Aud 3 Wave Duty",
-            AudioRegs::Vol3 => "Aud 3 Vol",
-            AudioRegs::Af3 => "Aud 3 Freq",
-            AudioRegs::Ctl3 => "Aud 3 Ctl",
-            AudioRegs::Pwm4 => "Aud 4 Wave Duty",
-            AudioRegs::Vol4 => "Aud 4 Vol",
-            AudioRegs::Af4 => "Aud 4 Freq",
-            AudioRegs::Ctl4 => "Aud 4 Ctl",
-            AudioRegs::AudOutMap => "Aud Output Mapping",
-            AudioRegs::AudMap => "Aud Mapping",
-            AudioRegs::AudChanCtl => "Aud Channel Ctl",
-            AudioRegs::AudWave => "Aud Wave",
+            AudioRegs::Pwm3 => "Audio 3 Wave Duty",
+            AudioRegs::Vol3 => "Audio 3 Vol",
+            AudioRegs::Af3 => "Audio 3 Freq",
+            AudioRegs::Ctl3 => "Audio 3 Ctl",
+            AudioRegs::Pwm4 => "Audio 4 Wave Duty",
+            AudioRegs::Vol4 => "Audio 4 Vol",
+            AudioRegs::Af4 => "Audio 4 Freq",
+            AudioRegs::Ctl4 => "Audio 4 Ctl",
+            AudioRegs::AudOutMap => "Audio Output Mapping",
+            AudioRegs::AudMap => "Audio Mapping",
+            AudioRegs::AudChanCtl => "Audio Channel Ctl",
+            AudioRegs::AudWave => "Audio Wave",
         };
         write!(f, "{}", name)
     }
 }
-

--- a/gb-dbg/src/dbg_interfaces.rs
+++ b/gb-dbg/src/dbg_interfaces.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::fmt::{self, Display};
+use std::fmt::{self, Display, Formatter};
 
 pub struct RegisterMap<T: Display>(pub T, pub RegisterValue);
 
@@ -43,11 +43,15 @@ pub trait RegisterDebugOperations {
 
     fn io_get(&self, key: IORegs) -> Result<RegisterValue>;
 
+    fn audio_get(&self, key: AudioRegs) -> Result<RegisterValue>;
+
     fn cpu_registers(&self) -> Vec<RegisterMap<CpuRegs>>;
 
     fn ppu_registers(&self) -> Vec<RegisterMap<PpuRegs>>;
 
     fn io_registers(&self) -> Vec<RegisterMap<IORegs>>;
+
+    fn audio_registers(&self) -> Vec<RegisterMap<AudioRegs>>;
 }
 
 pub enum CpuRegs {
@@ -123,7 +127,27 @@ pub enum IORegs {
     Ie,
 
     BootRom,
+}
 
+impl Display for IORegs {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            IORegs::Joy => "Joypad",
+            IORegs::SerialByte => "Serial Byte",
+            IORegs::SerialControl => "Serial Control",
+            IORegs::Div => "Div",
+            IORegs::Tima => "Tima",
+            IORegs::Tma => "Tma",
+            IORegs::Tac => "TAc",
+            IORegs::If => "Interrupt Flag",
+            IORegs::Ie => "Interrupt Enable",
+            IORegs::BootRom => "BootRom",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+pub enum AudioRegs {
     Fs1,
     Pwm1,
     Env1,
@@ -152,42 +176,33 @@ pub enum IORegs {
     AudWave,
 }
 
-impl Display for IORegs {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for AudioRegs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let name = match self {
-            IORegs::Joy => "Joypad",
-            IORegs::SerialByte => "Serial Byte",
-            IORegs::SerialControl => "Serial Control",
-            IORegs::Div => "Div",
-            IORegs::Tima => "Tima",
-            IORegs::Tma => "Tma",
-            IORegs::Tac => "TAc",
-            IORegs::If => "Interrupt Flag",
-            IORegs::Ie => "Interrupt Enable",
-            IORegs::BootRom => "BootRom",
-            IORegs::Fs1 => "Aud 1 Sweep",
-            IORegs::Pwm1 => "Aud 1 Wave Duty",
-            IORegs::Env1 => "Aud 1 Envelope",
-            IORegs::Af1 => "Aud 1 Freq",
-            IORegs::Ctl1 => "Aud 1 Ctl",
-            IORegs::Pwm2 => "Aud 2 Wave Duty",
-            IORegs::Env2 => "Aud 2 Envelope",
-            IORegs::Af2 => "Aud 2 Freq",
-            IORegs::Ctl2 => "Aud 2 Ctl",
-            IORegs::A3Toggle => "Audio Channel 3 Toggle",
-            IORegs::Pwm3 => "Aud 3 Wave Duty",
-            IORegs::Vol3 => "Aud 3 Vol",
-            IORegs::Af3 => "Aud 3 Freq",
-            IORegs::Ctl3 => "Aud 3 Ctl",
-            IORegs::Pwm4 => "Aud 4 Wave Duty",
-            IORegs::Vol4 => "Aud 4 Vol",
-            IORegs::Af4 => "Aud 4 Freq",
-            IORegs::Ctl4 => "Aud 4 Ctl",
-            IORegs::AudOutMap => "Aud Output Mapping",
-            IORegs::AudMap => "Aud Mapping",
-            IORegs::AudChanCtl => "Aud Channel Ctl",
-            IORegs::AudWave => "Aud Wave",
+            AudioRegs::Fs1 => "Aud 1 Sweep",
+            AudioRegs::Pwm1 => "Aud 1 Wave Duty",
+            AudioRegs::Env1 => "Aud 1 Envelope",
+            AudioRegs::Af1 => "Aud 1 Freq",
+            AudioRegs::Ctl1 => "Aud 1 Ctl",
+            AudioRegs::Pwm2 => "Aud 2 Wave Duty",
+            AudioRegs::Env2 => "Aud 2 Envelope",
+            AudioRegs::Af2 => "Aud 2 Freq",
+            AudioRegs::Ctl2 => "Aud 2 Ctl",
+            AudioRegs::A3Toggle => "Audio Channel 3 Toggle",
+            AudioRegs::Pwm3 => "Aud 3 Wave Duty",
+            AudioRegs::Vol3 => "Aud 3 Vol",
+            AudioRegs::Af3 => "Aud 3 Freq",
+            AudioRegs::Ctl3 => "Aud 3 Ctl",
+            AudioRegs::Pwm4 => "Aud 4 Wave Duty",
+            AudioRegs::Vol4 => "Aud 4 Vol",
+            AudioRegs::Af4 => "Aud 4 Freq",
+            AudioRegs::Ctl4 => "Aud 4 Ctl",
+            AudioRegs::AudOutMap => "Aud Output Mapping",
+            AudioRegs::AudMap => "Aud Mapping",
+            AudioRegs::AudChanCtl => "Aud Channel Ctl",
+            AudioRegs::AudWave => "Aud Wave",
         };
         write!(f, "{}", name)
     }
 }
+

--- a/gb-dbg/src/debugger.rs
+++ b/gb-dbg/src/debugger.rs
@@ -46,7 +46,7 @@ impl<MEM: DebugOperations> Debugger<MEM> {
 
         egui::SidePanel::right("right_panel")
             .resizable(false)
-            .default_width(170.0)
+            .default_width(130.0)
             .show(ctx, |ui| {
                 if Some(ControlFlow::Break(Until::Null))
                     == self

--- a/gb-dbg/src/debugger/registers.rs
+++ b/gb-dbg/src/debugger/registers.rs
@@ -20,19 +20,20 @@ impl RegisterEditor {
             self.draw_register_table(register.cpu_registers(), "CPU", ui);
             self.draw_register_table(register.ppu_registers(), "PPU", ui);
             self.draw_register_table(register.io_registers(), "IO", ui);
+            self.draw_register_table(register.audio_registers(), "AUDIO", ui);
         });
         ui.add_space(58.0);
         ui.separator();
     }
 
-    fn draw_register_table<T: std::fmt::Display>(
+    fn draw_register_table<T: std::fmt::Display + std::fmt::Debug>(
         &self,
         registers: Vec<RegisterMap<T>>,
         name: &str,
         ui: &mut Ui,
     ) {
         let layout = egui::Layout::top_down(egui::Align::LEFT);
-        ui.allocate_ui_with_layout(Vec2::new(80.0, 150.0), layout, |ui| {
+        ui.allocate_ui_with_layout(Vec2::new(125.0, 150.0), layout, |ui| {
             ui.colored_label(Color32::WHITE, name);
             ui.horizontal(|ui| {
                 ui.colored_label(Color32::WHITE, "Name");
@@ -44,7 +45,7 @@ impl RegisterEditor {
                 .show(ui, |ui| {
                     egui::Grid::new("Grid_".to_owned() + name)
                         .striped(true)
-                        .spacing(Vec2::new(2.5, 2.5))
+                        .spacing(Vec2::new(3.5, 2.5))
                         .show(ui, |ui| {
                             for row in registers.iter() {
                                 let value: u16 = row.1.into();
@@ -54,7 +55,8 @@ impl RegisterEditor {
                                     format!("0x{:02X}", value)
                                 };
 
-                                ui.label(egui::Label::new(&row.0));
+                                ui.label(egui::Label::new(format!("{:?}", &row.0)))
+                                    .on_hover_text(&row.0);
                                 ui.label(egui::Label::new(format));
                                 ui.end_row();
                             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,6 +5,7 @@ use gb_bus::{
 };
 use gb_clock::Clock;
 use gb_cpu::cpu::Cpu;
+use gb_dbg::dbg_interfaces::AudioRegs;
 use gb_dbg::{
     dbg_interfaces::{
         CpuRegs, DebugOperations, IORegs, MemoryDebugOperations, PpuRegs, RegisterDebugOperations,
@@ -27,7 +28,6 @@ use gb_roms::{
 use gb_timer::Timer;
 use std::collections::HashMap;
 use std::{cell::RefCell, rc::Rc};
-use gb_dbg::dbg_interfaces::AudioRegs;
 
 pub struct Context<const WIDTH: usize, const HEIGHT: usize> {
     pub sdl: sdl2::Sdl,

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,6 +27,7 @@ use gb_roms::{
 use gb_timer::Timer;
 use std::collections::HashMap;
 use std::{cell::RefCell, rc::Rc};
+use gb_dbg::dbg_interfaces::AudioRegs;
 
 pub struct Context<const WIDTH: usize, const HEIGHT: usize> {
     pub sdl: sdl2::Sdl,
@@ -290,7 +291,7 @@ impl RegisterDebugOperations for Game {
             IORegs::Joy => Ok(read_bus_reg!(self.addr_bus, 0xFF00)),
             // serial regs
             IORegs::SerialByte => Ok(read_bus_reg!(self.addr_bus, 0xFF01)),
-            IORegs::SerialControl => Ok(read_bus_reg!(self.addr_bus, 0xFF02)),
+            IORegs::SerialCtl => Ok(read_bus_reg!(self.addr_bus, 0xFF02)),
             // Timer regs
             IORegs::Div => Ok(read_bus_reg!(self.addr_bus, 0xFF04)),
             IORegs::Tima => Ok(read_bus_reg!(self.addr_bus, 0xFF05)),
@@ -301,29 +302,33 @@ impl RegisterDebugOperations for Game {
             IORegs::Ie => Ok(read_bus_reg!(self.addr_bus, 0xFFFF)),
             // Boot ROM
             IORegs::BootRom => Ok(read_bus_reg!(self.addr_bus, 0xFF50)),
-            // audio regs
-            IORegs::Fs1 => Ok(read_bus_reg!(self.addr_bus, 0xFF10)),
-            IORegs::Pwm1 => Ok(read_bus_reg!(self.addr_bus, 0xFF11)),
-            IORegs::Env1 => Ok(read_bus_reg!(self.addr_bus, 0xFF12)),
-            IORegs::Af1 => Ok(read_bus_reg!(self.addr_bus, 0xFF13)),
-            IORegs::Ctl1 => Ok(read_bus_reg!(self.addr_bus, 0xFF14)),
-            IORegs::Pwm2 => Ok(read_bus_reg!(self.addr_bus, 0xFF16)),
-            IORegs::Env2 => Ok(read_bus_reg!(self.addr_bus, 0xFF17)),
-            IORegs::Af2 => Ok(read_bus_reg!(self.addr_bus, 0xFF18)),
-            IORegs::Ctl2 => Ok(read_bus_reg!(self.addr_bus, 0xFF19)),
-            IORegs::A3Toggle => Ok(read_bus_reg!(self.addr_bus, 0xFF1A)),
-            IORegs::Pwm3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1B)),
-            IORegs::Vol3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1C)),
-            IORegs::Af3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1D)),
-            IORegs::Ctl3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1E)),
-            IORegs::Pwm4 => Ok(read_bus_reg!(self.addr_bus, 0xFF20)),
-            IORegs::Vol4 => Ok(read_bus_reg!(self.addr_bus, 0xFF21)),
-            IORegs::Af4 => Ok(read_bus_reg!(self.addr_bus, 0xFF22)),
-            IORegs::Ctl4 => Ok(read_bus_reg!(self.addr_bus, 0xFF23)),
-            IORegs::AudOutMap => Ok(read_bus_reg!(self.addr_bus, 0xFF24)),
-            IORegs::AudMap => Ok(read_bus_reg!(self.addr_bus, 0xFF25)),
-            IORegs::AudChanCtl => Ok(read_bus_reg!(self.addr_bus, 0xFF26)),
-            IORegs::AudWave => Ok(read_bus_reg!(self.addr_bus, 0xFF30)),
+        }
+    }
+
+    fn audio_get(&self, key: AudioRegs) -> Result<RegisterValue> {
+        match key {
+            AudioRegs::Fs1 => Ok(read_bus_reg!(self.addr_bus, 0xFF10)),
+            AudioRegs::Pwm1 => Ok(read_bus_reg!(self.addr_bus, 0xFF11)),
+            AudioRegs::Env1 => Ok(read_bus_reg!(self.addr_bus, 0xFF12)),
+            AudioRegs::Af1 => Ok(read_bus_reg!(self.addr_bus, 0xFF13)),
+            AudioRegs::Ctl1 => Ok(read_bus_reg!(self.addr_bus, 0xFF14)),
+            AudioRegs::Pwm2 => Ok(read_bus_reg!(self.addr_bus, 0xFF16)),
+            AudioRegs::Env2 => Ok(read_bus_reg!(self.addr_bus, 0xFF17)),
+            AudioRegs::Af2 => Ok(read_bus_reg!(self.addr_bus, 0xFF18)),
+            AudioRegs::Ctl2 => Ok(read_bus_reg!(self.addr_bus, 0xFF19)),
+            AudioRegs::A3Toggle => Ok(read_bus_reg!(self.addr_bus, 0xFF1A)),
+            AudioRegs::Pwm3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1B)),
+            AudioRegs::Vol3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1C)),
+            AudioRegs::Af3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1D)),
+            AudioRegs::Ctl3 => Ok(read_bus_reg!(self.addr_bus, 0xFF1E)),
+            AudioRegs::Pwm4 => Ok(read_bus_reg!(self.addr_bus, 0xFF20)),
+            AudioRegs::Vol4 => Ok(read_bus_reg!(self.addr_bus, 0xFF21)),
+            AudioRegs::Af4 => Ok(read_bus_reg!(self.addr_bus, 0xFF22)),
+            AudioRegs::Ctl4 => Ok(read_bus_reg!(self.addr_bus, 0xFF23)),
+            AudioRegs::AudOutMap => Ok(read_bus_reg!(self.addr_bus, 0xFF24)),
+            AudioRegs::AudMap => Ok(read_bus_reg!(self.addr_bus, 0xFF25)),
+            AudioRegs::AudChanCtl => Ok(read_bus_reg!(self.addr_bus, 0xFF26)),
+            AudioRegs::AudWave => Ok(read_bus_reg!(self.addr_bus, 0xFF30)),
         }
     }
 
@@ -362,7 +367,7 @@ impl RegisterDebugOperations for Game {
             read_bus_reg!(IORegs::Joy, self.addr_bus, 0xFF00),
             // serial regs
             read_bus_reg!(IORegs::SerialByte, self.addr_bus, 0xFF01),
-            read_bus_reg!(IORegs::SerialControl, self.addr_bus, 0xFF02),
+            read_bus_reg!(IORegs::SerialCtl, self.addr_bus, 0xFF02),
             // Timer regs
             read_bus_reg!(IORegs::Div, self.addr_bus, 0xFF04),
             read_bus_reg!(IORegs::Tima, self.addr_bus, 0xFF05),
@@ -373,29 +378,33 @@ impl RegisterDebugOperations for Game {
             read_bus_reg!(IORegs::Ie, self.addr_bus, 0xFFFF),
             // Boot ROM
             read_bus_reg!(IORegs::BootRom, self.addr_bus, 0xFF50),
-            // audio regs
-            read_bus_reg!(IORegs::Fs1, self.addr_bus, 0xFF10),
-            read_bus_reg!(IORegs::Pwm1, self.addr_bus, 0xFF11),
-            read_bus_reg!(IORegs::Env1, self.addr_bus, 0xFF12),
-            read_bus_reg!(IORegs::Af1, self.addr_bus, 0xFF13),
-            read_bus_reg!(IORegs::Ctl1, self.addr_bus, 0xFF14),
-            read_bus_reg!(IORegs::Pwm2, self.addr_bus, 0xFF16),
-            read_bus_reg!(IORegs::Env2, self.addr_bus, 0xFF17),
-            read_bus_reg!(IORegs::Af2, self.addr_bus, 0xFF18),
-            read_bus_reg!(IORegs::Ctl2, self.addr_bus, 0xFF19),
-            read_bus_reg!(IORegs::A3Toggle, self.addr_bus, 0xFF1A),
-            read_bus_reg!(IORegs::Pwm3, self.addr_bus, 0xFF1B),
-            read_bus_reg!(IORegs::Vol3, self.addr_bus, 0xFF1C),
-            read_bus_reg!(IORegs::Af3, self.addr_bus, 0xFF1D),
-            read_bus_reg!(IORegs::Ctl3, self.addr_bus, 0xFF1E),
-            read_bus_reg!(IORegs::Pwm4, self.addr_bus, 0xFF20),
-            read_bus_reg!(IORegs::Vol4, self.addr_bus, 0xFF21),
-            read_bus_reg!(IORegs::Af4, self.addr_bus, 0xFF22),
-            read_bus_reg!(IORegs::Ctl4, self.addr_bus, 0xFF23),
-            read_bus_reg!(IORegs::AudOutMap, self.addr_bus, 0xFF24),
-            read_bus_reg!(IORegs::AudMap, self.addr_bus, 0xFF25),
-            read_bus_reg!(IORegs::AudChanCtl, self.addr_bus, 0xFF26),
-            read_bus_reg!(IORegs::AudWave, self.addr_bus, 0xFF30),
+        ]
+    }
+
+    fn audio_registers(&self) -> Vec<RegisterMap<AudioRegs>> {
+        vec![
+            read_bus_reg!(AudioRegs::Fs1, self.addr_bus, 0xFF10),
+            read_bus_reg!(AudioRegs::Pwm1, self.addr_bus, 0xFF11),
+            read_bus_reg!(AudioRegs::Env1, self.addr_bus, 0xFF12),
+            read_bus_reg!(AudioRegs::Af1, self.addr_bus, 0xFF13),
+            read_bus_reg!(AudioRegs::Ctl1, self.addr_bus, 0xFF14),
+            read_bus_reg!(AudioRegs::Pwm2, self.addr_bus, 0xFF16),
+            read_bus_reg!(AudioRegs::Env2, self.addr_bus, 0xFF17),
+            read_bus_reg!(AudioRegs::Af2, self.addr_bus, 0xFF18),
+            read_bus_reg!(AudioRegs::Ctl2, self.addr_bus, 0xFF19),
+            read_bus_reg!(AudioRegs::A3Toggle, self.addr_bus, 0xFF1A),
+            read_bus_reg!(AudioRegs::Pwm3, self.addr_bus, 0xFF1B),
+            read_bus_reg!(AudioRegs::Vol3, self.addr_bus, 0xFF1C),
+            read_bus_reg!(AudioRegs::Af3, self.addr_bus, 0xFF1D),
+            read_bus_reg!(AudioRegs::Ctl3, self.addr_bus, 0xFF1E),
+            read_bus_reg!(AudioRegs::Pwm4, self.addr_bus, 0xFF20),
+            read_bus_reg!(AudioRegs::Vol4, self.addr_bus, 0xFF21),
+            read_bus_reg!(AudioRegs::Af4, self.addr_bus, 0xFF22),
+            read_bus_reg!(AudioRegs::Ctl4, self.addr_bus, 0xFF23),
+            read_bus_reg!(AudioRegs::AudOutMap, self.addr_bus, 0xFF24),
+            read_bus_reg!(AudioRegs::AudMap, self.addr_bus, 0xFF25),
+            read_bus_reg!(AudioRegs::AudChanCtl, self.addr_bus, 0xFF26),
+            read_bus_reg!(AudioRegs::AudWave, self.addr_bus, 0xFF30),
         ]
     }
 }


### PR DESCRIPTION
This adds a register set `Audio` to reduce the size of the Io register set.
This also adds tool tips for labels for each register because the size of the register names would stretch the layout.