### PR TITLE
Fix pc being incremented as soon as the instruction is fetched

### DIFF
--- a/gb-cpu/src/microcode/fetch.rs
+++ b/gb-cpu/src/microcode/fetch.rs
@@ -14,7 +14,7 @@ use std::{cell::RefCell, convert::TryFrom, rc::Rc};
 pub fn fetch(ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow {
     let current_pc = state.regs.pc;
     let ctl_ref = Rc::new(RefCell::new(ctl));
-    let byte = state.read();
+    let byte = state.read_bus(current_pc);
     Opcode::try_from(byte).map_or_else(
         |e| {
             ctl_ref.borrow_mut().opcode = None;
@@ -639,6 +639,7 @@ pub fn fetch(ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow 
                 Opcode::PrefixCb => ctl.push_action(fetch_cb),
                 _ => todo!("unimplemented opcode {:?}", opcode),
             };
+            ctl.push_action(utils::inc_pc);
             MicrocodeFlow::Continue(CycleDigest::Consume)
         },
     )

--- a/gb-cpu/src/microcode/fetch_cb.rs
+++ b/gb-cpu/src/microcode/fetch_cb.rs
@@ -1,4 +1,4 @@
-use crate::microcode::write;
+use crate::microcode::{utils, write};
 
 use super::{
     bitwise, opcode_cb::OpcodeCB, read, CycleDigest, MicrocodeController, MicrocodeFlow, State,
@@ -6,7 +6,7 @@ use super::{
 use std::convert::TryFrom;
 
 pub fn fetch_cb(ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow {
-    let byte = state.read();
+    let byte = state.read_bus(state.regs.pc);
     OpcodeCB::try_from(byte).map_or_else(
         |e| {
             panic!(
@@ -354,6 +354,7 @@ pub fn fetch_cb(ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFl
                 }
                 OpcodeCB::SwapA => ctl.push_actions(&[read::a, bitwise::swap, write::a]),
             };
+            ctl.push_action(utils::inc_pc);
             MicrocodeFlow::Continue(CycleDigest::Consume)
         },
     )

--- a/gb-cpu/src/microcode/utils.rs
+++ b/gb-cpu/src/microcode/utils.rs
@@ -1,5 +1,10 @@
-use super::{MicrocodeController, MicrocodeFlow, State, OK_CONSUME_CYCLE};
+use super::{MicrocodeController, MicrocodeFlow, State, OK_CONSUME_CYCLE, OK_PLAY_NEXT_ACTION};
 
 pub fn sleep(_ctl: &mut MicrocodeController, _state: &mut State) -> MicrocodeFlow {
     OK_CONSUME_CYCLE
+}
+
+pub fn inc_pc(_ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow {
+    state.regs.pc += 1;
+    OK_PLAY_NEXT_ACTION
 }


### PR DESCRIPTION
To have an easier time debugging instruction, it appears to be best to delay the PC increment to after the instruction fetch.

**Important**
This branch isn't meant to be merge on develop because it would break the current implementation of the debugger.
It is meant to be peer validated and then merged to this other PR => #400