### PR TITLE
fix - wrong number of cycles when handling interrupts

### DIFF
--- a/gb-cpu/src/microcode/interrupts.rs
+++ b/gb-cpu/src/microcode/interrupts.rs
@@ -31,21 +31,16 @@ pub fn handle_interrupts(ctl: &mut MicrocodeController, state: &mut State) -> Mi
     // Push interrupt source address to cache
     ctl.push_u16(0x0040 | ((source_bit as u16) << 3));
 
-    ctl.push_to_current_cycle(&[
-        // Sleep (2 mcycles)
-        sleep,
-        sleep,
-        // Store pc into stack (2 mcycles)
-        read::pc,
-        dec::sp,
-        read::sp,
-        write::ind,
-        dec::sp,
-        read::sp,
-        write::ind,
-        // Jump to interrupt source address (1 mcycle)
-        jump,
+    ctl.push_cycles(&[
+        // Store pc into stack
+        &[read::pc, dec::sp, read::sp],
+        &[write::ind],
+        &[dec::sp, read::sp],
+        &[write::ind],
+        // Jump to interrupt source address
+        &[jump],
     ]);
+
     CONTINUE
 }
 

--- a/gb-cpu/src/microcode/interrupts.rs
+++ b/gb-cpu/src/microcode/interrupts.rs
@@ -1,6 +1,4 @@
-use super::{
-    dec, jump::jump, read, utils::sleep, write, MicrocodeController, MicrocodeFlow, State, CONTINUE,
-};
+use super::{dec, jump::jump, read, write, MicrocodeController, MicrocodeFlow, State, CONTINUE};
 
 pub fn handle_interrupts(ctl: &mut MicrocodeController, state: &mut State) -> MicrocodeFlow {
     let mut int_flags = state.int_flags.borrow_mut();


### PR DESCRIPTION
5 mcycles are executed after an interrupt is triggered to store the pc in the stack and then jump to the interrupt source endpoint