### PR TITLE
Ignore bit 0 for 8x16 sprites.

### DIFF
--- a/gb-ppu/src/sprite.rs
+++ b/gb-ppu/src/sprite.rs
@@ -36,6 +36,8 @@ impl<'r> Sprite {
     pub const VERTICAL_OFFSET: u8 = 16;
     pub const HORIZONTAL_OFFSET: u8 = 8;
 
+    pub const TILE_INDEX_MASK: u8 = 0b1111_1110;
+
     pub fn new() -> Self {
         Sprite {
             y_pos: 0,
@@ -149,9 +151,9 @@ impl<'r> Sprite {
             });
         }
         let index = if line > 7 && !self.y_flip() || line < 8 && self.y_flip() {
-            self.tile_index as usize + 1
+            (self.tile_index & Self::TILE_INDEX_MASK) as usize + 1
         } else {
-            self.tile_index as usize
+            (self.tile_index & Self::TILE_INDEX_MASK) as usize
         };
         if line > 7 {
             line -= 8


### PR DESCRIPTION
close #443 