### PR TITLE
Feature/simple serial

### DIFF
--- a/gb-bus/src/lib.rs
+++ b/gb-bus/src/lib.rs
@@ -9,6 +9,7 @@ pub mod io_reg_area;
 mod io_reg_bus;
 pub mod io_reg_constant;
 mod lock;
+mod serial;
 mod working_ram;
 
 pub use address::Addr;
@@ -19,6 +20,7 @@ pub use file_operation::{Address, FileOperation};
 pub use io_reg_area::IORegArea;
 pub use io_reg_bus::{IORegBus, IORegBusBuilder};
 pub use lock::{InternalLock, Lock, MemoryLock};
+pub use serial::Serial;
 pub use working_ram::WorkingRam;
 
 pub trait Bus<N>: MemoryLock {

--- a/gb-bus/src/serial.rs
+++ b/gb-bus/src/serial.rs
@@ -1,0 +1,59 @@
+use crate::{Address, Error, FileOperation, IORegArea};
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Serial {
+    payload: u8,
+    control: u8,
+}
+
+impl Serial {
+    #[cfg(feature = "cgb")]
+    const SC_MASK: u8 = 0x7c;
+    #[cfg(not(feature = "cgb"))]
+    const SC_MASK: u8 = 0x7e;
+
+    const TRANSFER_FIELD: u8 = 0x80;
+    const CLOCK_FIELD: u8 = 0x1;
+
+    fn internal_data_to_transfer(&self) -> bool {
+        self.control & (Serial::TRANSFER_FIELD | Serial::CLOCK_FIELD)
+            == (Serial::TRANSFER_FIELD | Serial::CLOCK_FIELD)
+    }
+
+    fn transfer_finished(&mut self) {
+        self.control &= !Serial::TRANSFER_FIELD;
+    }
+
+    fn update(&mut self) {
+        if self.internal_data_to_transfer() {
+            log::info!("Serial: {0:#02x}", self.payload);
+            self.transfer_finished()
+        }
+    }
+}
+
+impl<A> FileOperation<A, IORegArea> for Serial
+where
+    u16: From<A>,
+    A: Address<IORegArea>,
+{
+    fn read(&self, addr: A) -> Result<u8, Error> {
+        match addr.area_type() {
+            IORegArea::SB => Ok(self.payload),
+            IORegArea::SC => Ok(self.control | Serial::SC_MASK),
+            _ => Err(Error::bus_error(addr.into())),
+        }
+    }
+
+    fn write(&mut self, v: u8, addr: A) -> Result<(), Error> {
+        match addr.area_type() {
+            IORegArea::SB => self.payload = v,
+            IORegArea::SC => {
+                self.control = v & !Serial::SC_MASK;
+                self.update();
+            }
+            _ => return Err(Error::bus_error(addr.into())),
+        }
+        Ok(())
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -110,6 +110,7 @@ impl Game {
             Rc::new(RefCell::new(wrapper))
         };
         let dma = Rc::new(RefCell::new(Dma::new()));
+        let serial = Rc::new(RefCell::new(gb_bus::Serial::default()));
 
         let io_bus = {
             let mut bus_builder = IORegBusBuilder::default();
@@ -133,7 +134,8 @@ impl Game {
                 .with_area(IORegArea::Wy, ppu_reg.clone())
                 .with_area(IORegArea::Wx, ppu_reg)
                 .with_area(IORegArea::BootRom, bios_wrapper.clone())
-                .with_default_serial()
+                .with_area(IORegArea::SC, serial.clone())
+                .with_area(IORegArea::SB, serial)
                 .with_default_sound()
                 .with_default_waveform_ram();
 


### PR DESCRIPTION
implement a basic write-only serial (the game can only output data, not read data)

these changes mainly allow for tests rom (like mooneye-test-suite, blaargs-test) to output data to the serial 