### PR TITLE
Bugfix/breakpoint expr

### DIFF
--- a/gb-dbg/src/debugger/breakpoints/test_parser.rs
+++ b/gb-dbg/src/debugger/breakpoints/test_parser.rs
@@ -117,6 +117,7 @@ mod unit_expr {
             "AF == 0x21 || PC == 0xDEAD",
         );
     }
+
     #[test]
     fn space() {
         utils_test_expr(expr_complete, "AF ==42", "AF == 0x42");
@@ -125,5 +126,11 @@ mod unit_expr {
             "AF== 21 ||PC== dead",
             "AF == 0x21 || PC == 0xDEAD",
         );
+    }
+
+    #[test]
+    fn simple() {
+        utils_test_expr(expr_complete, "HL == b000", "HL == 0xB000");
+        utils_test_expr(expr_complete, "*4088 == e3", "*0x4088 == 0xE3");
     }
 }


### PR DESCRIPTION
correct a bug on the breakpoint editor where when a breakpoint is triggered, the user can't add any new breakpoint.

A check was made to prevent user to add duplicates breakpoints by checking if any breakpoints was triggered (which there was).
To prevent duplicates, [`HashSet`](https://doc.rust-lang.org/std/collections/hash_set/struct.HashSet.html) seems to be the way

closes #514, closes #518 