### PR TITLE
Feature/improve fps display

### DIFF
--- a/gb-dbg/src/debugger.rs
+++ b/gb-dbg/src/debugger.rs
@@ -30,7 +30,12 @@ pub struct Debugger<DBGOPS> {
 }
 
 impl<DBGOPS: DebugOperations> Debugger<DBGOPS> {
-    pub fn draw(&mut self, ui_ctx: &CtxRef, game_ctx: &mut DBGOPS, fps: Option<f64>) {
+    pub fn draw(
+        &mut self,
+        ui_ctx: &CtxRef,
+        game_ctx: &mut DBGOPS,
+        info: Option<(&dyn ToString, &dyn ToString)>,
+    ) {
         // ctx.set_debug_on_hover(true);
 
         // Set style for all UI
@@ -96,7 +101,7 @@ impl<DBGOPS: DebugOperations> Debugger<DBGOPS> {
                         self.disassembler.draw(ui);
                         ui.end_row();
 
-                        self.status_bar.draw(ui, game_ctx, fps);
+                        self.status_bar.draw(ui, game_ctx, info);
                         ui.end_row();
 
                         self.register_editor.draw(ui, game_ctx);

--- a/gb-dbg/src/debugger/status_bar.rs
+++ b/gb-dbg/src/debugger/status_bar.rs
@@ -16,15 +16,20 @@ const SELECT_ACTION: u16 = 0b0010_0000;
 pub struct StatusBar;
 
 impl StatusBar {
-    pub fn draw<DBG: DebugOperations>(&self, ui: &mut Ui, regs: &DBG, fps: Option<f64>) {
+    pub fn draw<DBG: DebugOperations>(
+        &self,
+        ui: &mut Ui,
+        regs: &DBG,
+        info: Option<(&dyn ToString, &dyn ToString)>,
+    ) {
         ui.vertical(|ui| {
             ui.colored_label(Color32::LIGHT_BLUE, "Status");
             ui.separator();
             ui.horizontal(|ui| {
                 display_flags(ui, u16::from(regs.cpu_get(CpuRegs::AF)));
                 display_key(ui, u16::from(regs.io_get(IORegs::Joy)));
-                if let Some(fps_count) = fps {
-                    display_fps(ui, fps_count);
+                if let Some(info_tuple) = info {
+                    display_info(ui, info_tuple);
                 }
             });
         });
@@ -73,7 +78,7 @@ fn display_flags(ui: &mut Ui, af_reg: u16) {
     ui.colored_label(Color32::WHITE, f_display.into_iter().collect::<String>());
 }
 
-fn display_fps(ui: &mut Ui, fps: f64) {
-    ui.colored_label(Color32::GOLD, "FPS: ");
-    ui.colored_label(Color32::WHITE, format!("{:>7.2}", fps));
+fn display_info(ui: &mut Ui, info: (&dyn ToString, &dyn ToString)) {
+    ui.colored_label(Color32::GOLD, format!("{}: ", info.0.to_string()));
+    ui.colored_label(Color32::WHITE, info.1.to_string());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,10 +108,14 @@ fn main() {
                 dgb_wind
                     .start_frame()
                     .expect("Fail at the start for the debug window");
-                #[cfg(not(feature = "debug_fps"))]
+                #[cfg(not(feature = "time_frame"))]
                 debugger.draw(dgb_wind.egui_ctx(), game, None);
-                #[cfg(feature = "debug_fps")]
-                debugger.draw(dgb_wind.egui_ctx(), game, Some(render_time_frame.fps()));
+                #[cfg(feature = "time_frame")]
+                debugger.draw(
+                    dgb_wind.egui_ctx(),
+                    game,
+                    Some((&"time frame", &time_frame_stat)),
+                );
                 dgb_wind
                     .end_frame()
                     .expect("Fail at the end for the debug window");

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,10 @@ fn main() {
             }
             game.draw(&mut context);
         }
+        #[cfg(not(feature = "debug_fps"))]
         let events = ui::draw_egui(&mut context);
+        #[cfg(feature = "debug_fps")]
+        let events = ui::draw_egui(&mut context, render_time_frame.fps());
         context
             .windows
             .main

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,6 +20,7 @@ macro_rules! replace_windows {
 macro_rules! ui_debug {
     ($ui:expr, $context:expr) => {
         $ui.menu_button("🔧", |ui| {
+            ui.style_mut().override_text_style = None;
             if ui.button("Cpu").clicked() && $context.windows.debug.is_none() {
                 replace_windows!($context, debug, new_debug_window(&$context.video));
             }
@@ -42,6 +43,7 @@ macro_rules! ui_debug {
 macro_rules! ui_settings {
     ($ui:expr, $context:expr) => {
         $ui.menu_button("⚙", |ui| {
+            ui.style_mut().override_text_style = None;
             if ui.button("Input").clicked() && $context.windows.input.is_none() {
                 $context.windows.input.replace(
                     GBWindow::new(
@@ -78,9 +80,11 @@ pub fn draw_egui<const WIDTH: usize, const HEIGHT: usize>(
     egui::containers::TopBottomPanel::top("Top menu").show(context.windows.main.egui_ctx(), |ui| {
         egui::menu::bar(ui, |ui| {
             ui.set_height(render::MENU_BAR_SIZE);
+            ui.style_mut().override_text_style = Some(egui::TextStyle::Heading);
             ui_file(ui, &mut events);
             ui_debug!(ui, context);
             ui_settings!(ui, context);
+            ui.style_mut().override_text_style = None;
             #[cfg(feature = "debug_fps")]
             ui_fps!(ui, context, fps);
         });
@@ -174,6 +178,7 @@ pub fn draw_ppu_debug_ui<const WIDTH: usize, const HEIGHT: usize>(
 
 fn ui_file(ui: &mut Ui, events: &mut Vec<CustomEvent>) {
     ui.menu_button("💾", |ui| {
+        ui.style_mut().override_text_style = None;
         if ui.button("Load").clicked() {
             let file = FileDialog::new()
                 .set_location(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -62,8 +62,17 @@ macro_rules! ui_settings {
     };
 }
 
+#[cfg(feature = "debug_fps")]
+macro_rules! ui_fps {
+    ($ui:expr, $context:expr, $fps:expr) => {
+        $ui.add_space($ui.available_size().x - 50.0);
+        $ui.label((format!("{:>7.2}", $fps)));
+    };
+}
+
 pub fn draw_egui<const WIDTH: usize, const HEIGHT: usize>(
     context: &mut Context<WIDTH, HEIGHT>,
+    #[cfg(feature = "debug_fps")] fps: f64,
 ) -> Vec<CustomEvent> {
     let mut events = Vec::new();
     egui::containers::TopBottomPanel::top("Top menu").show(context.windows.main.egui_ctx(), |ui| {
@@ -72,7 +81,9 @@ pub fn draw_egui<const WIDTH: usize, const HEIGHT: usize>(
             ui_file(ui, &mut events);
             ui_debug!(ui, context);
             ui_settings!(ui, context);
-        })
+            #[cfg(feature = "debug_fps")]
+            ui_fps!(ui, context, fps);
+        });
     });
     events
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -19,7 +19,7 @@ macro_rules! replace_windows {
 
 macro_rules! ui_debug {
     ($ui:expr, $context:expr) => {
-        $ui.menu_button("Debug", |ui| {
+        $ui.menu_button("🔧", |ui| {
             if ui.button("Cpu").clicked() && $context.windows.debug.is_none() {
                 replace_windows!($context, debug, new_debug_window(&$context.video));
             }
@@ -41,22 +41,24 @@ macro_rules! ui_debug {
 
 macro_rules! ui_settings {
     ($ui:expr, $context:expr) => {
-        if $ui.button("Input").clicked() && $context.windows.input.is_none() {
-            $context.windows.input.replace(
-                GBWindow::new(
-                    "GBMU Input Settings",
-                    (
-                        GBWindow::dots_to_pixels(&$context.video, 250.0)
-                            .expect("error while computing window size"),
-                        GBWindow::dots_to_pixels(&$context.video, 250.0)
-                            .expect("error while computing window size"),
-                    ),
-                    false,
-                    &$context.video,
-                )
-                .expect("Error while building input window"),
-            );
-        }
+        $ui.menu_button("⚙", |ui| {
+            if ui.button("Input").clicked() && $context.windows.input.is_none() {
+                $context.windows.input.replace(
+                    GBWindow::new(
+                        "GBMU Input Settings",
+                        (
+                            GBWindow::dots_to_pixels(&$context.video, 250.0)
+                                .expect("error while computing window size"),
+                            GBWindow::dots_to_pixels(&$context.video, 250.0)
+                                .expect("error while computing window size"),
+                        ),
+                        false,
+                        &$context.video,
+                    )
+                    .expect("Error while building input window"),
+                );
+            }
+        });
     };
 }
 
@@ -92,7 +94,7 @@ pub fn draw_ppu_debug_ui<const WIDTH: usize, const HEIGHT: usize>(
                 |ui| {
                     egui::menu::bar(ui, |ui| {
                         ui.set_height(render::MENU_BAR_SIZE);
-                        egui::menu::menu(ui, "bg/win", |ui| {
+                        ui.menu_button("bg/win", |ui| {
                             if ui.button("background").clicked() {
                                 *display_window = false;
                             }
@@ -132,7 +134,7 @@ pub fn draw_ppu_debug_ui<const WIDTH: usize, const HEIGHT: usize>(
             egui::containers::TopBottomPanel::top("Top menu").show(cfg.window.egui_ctx(), |ui| {
                 egui::menu::bar(ui, |ui| {
                     ui.set_height(render::MENU_BAR_SIZE);
-                    egui::menu::menu(ui, "mode", |ui| {
+                    ui.menu_button("mode", |ui| {
                         if ui.button("viewport").clicked() {
                             cfg.display_list = false;
                         }
@@ -160,7 +162,7 @@ pub fn draw_ppu_debug_ui<const WIDTH: usize, const HEIGHT: usize>(
 }
 
 fn ui_file(ui: &mut Ui, events: &mut Vec<CustomEvent>) {
-    ui.menu_button("File", |ui| {
+    ui.menu_button("💾", |ui| {
         if ui.button("Load").clicked() {
             let file = FileDialog::new()
                 .set_location(


### PR DESCRIPTION
 - more dense menu for the main window (with pretty unicode)
 - display fps on the main window menu bar instead of the debugger
 - replace the fps in the debugger by time frame info