### PR TITLE
rename `Cpu` field from `interrupt_flags` => `io_regs`

### DIFF
--- a/gb-cpu/src/builder.rs
+++ b/gb-cpu/src/builder.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 
 pub fn new_cpu() -> (Cpu, Rc<RefCell<IORegisters>>) {
     let cpu = Cpu::default();
-    let flags = cpu.interrupt_flags.clone();
+    let flags = cpu.io_regs.clone();
 
     (cpu, flags)
 }

--- a/gb-cpu/src/cpu.rs
+++ b/gb-cpu/src/cpu.rs
@@ -25,6 +25,6 @@ impl Ticker for Cpu {
 
     fn tick(&mut self, addr_bus: &mut dyn Bus<u8>) {
         self.controller
-            .step(self.interrupt_flags.clone(), &mut self.registers, addr_bus)
+            .step(self.io_regs.clone(), &mut self.registers, addr_bus)
     }
 }

--- a/gb-cpu/src/cpu.rs
+++ b/gb-cpu/src/cpu.rs
@@ -9,7 +9,7 @@ use std::{cell::RefCell, rc::Rc};
 pub struct Cpu {
     pub registers: Registers,
     pub controller: MicrocodeController,
-    pub interrupt_flags: Rc<RefCell<IORegisters>>,
+    pub io_regs: Rc<RefCell<IORegisters>>,
 }
 
 impl Cpu {

--- a/src/context.rs
+++ b/src/context.rs
@@ -696,12 +696,9 @@ impl RegisterDebugOperations for Game {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct SaveState {
     pub romname: String,
-<<<<<<< HEAD
     pub cpu_regs: gb_cpu::registers::Registers,
     pub cpu_io_regs: gb_cpu::io_registers::IORegisters,
-=======
     pub mbcs: GenericState<Full>,
->>>>>>> origin/develop
 }
 
 #[cfg(feature = "save_state")]
@@ -709,12 +706,9 @@ impl From<&Game> for SaveState {
     fn from(context: &Game) -> Self {
         Self {
             romname: context.romname.clone(),
-<<<<<<< HEAD
             cpu_regs: context.cpu.registers,
             cpu_io_regs: *context.cpu.interrupt_flags.borrow(),
-=======
             mbcs: context.mbc.borrow().save(),
->>>>>>> origin/develop
         }
     }
 }


### PR DESCRIPTION
closes #537 