### PR TITLE
increase windows program stack size

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(windows)]
+    println!("cargo:rustc-link-arg-bins=-Wl,-zstack-size=16777216");
+}


### PR DESCRIPTION
add a build script to pass link flags when compiling on windows to
increase the stack size

@Ragarnoy could you do the following check on windows to see if it resolve your problem

```shell
cargo clean # should remove /target
cargo -vv build >build.log 2>&1 # here I want the build log to be able to search something in the next step
grep 16777216 build.log # search for the stack-size defined in build.rs
```

if you see the value in the build log at least the build script is working.

closes #346 