### PR TITLE
fix `sdl2` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,15 +284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,7 +1980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3586be2cf6c0a8099a79a12b4084357aa9b3e0b0d7980e3b67aaf7a9d55f9f0"
 dependencies = [
  "cfg-if 1.0.0",
- "cmake",
  "libc",
  "version-compare",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ save_state = [
 ]
 
 [dependencies]
-sdl2 = { version = "0.35.2", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
 egui = "0.16"
 native-dialog = { version = "0.6" }
 log = { version = "0.4", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ save_state = [
 ]
 
 [dependencies]
-sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.2" }
 egui = "0.16"
 native-dialog = { version = "0.6" }
 log = { version = "0.4", features = ["std"] }

--- a/gb-joypad/Cargo.toml
+++ b/gb-joypad/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.2" }
 egui = "0.16"
 log = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }

--- a/gb-joypad/Cargo.toml
+++ b/gb-joypad/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-sdl2 = { version = "0.35", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
 egui = "0.16"
 log = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }

--- a/gb-lcd/Cargo.toml
+++ b/gb-lcd/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 debug_render = []
 
 [dependencies]
-sdl2 = { version = "0.35", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
 egui = "0.16"
 gl = { version = "0.14" }
 egui_sdl2_gl = { git = "https://github.com/FirelightFlagboy/egui_sdl2_gl", default-features = false, rev = "14f97af830a58088c2a1e54ca2b123dbb7caf992"  }

--- a/gb-lcd/Cargo.toml
+++ b/gb-lcd/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 debug_render = []
 
 [dependencies]
-sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.2" }
 egui = "0.16"
 gl = { version = "0.14" }
-egui_sdl2_gl = { git = "https://github.com/FirelightFlagboy/egui_sdl2_gl", default-features = false, rev = "14f97af830a58088c2a1e54ca2b123dbb7caf992"  }
+egui_sdl2_gl = { git = "https://github.com/FirelightFlagboy/egui_sdl2_gl", default-features = false, rev = "14f97af830a58088c2a1e54ca2b123dbb7caf992" }

--- a/gb-ppu/Cargo.toml
+++ b/gb-ppu/Cargo.toml
@@ -15,9 +15,15 @@ serde = { version = "1.0", features = ["std", "derive", "rc"], optional = true }
 serde-big-array = { version = "0.3", optional = true }
 
 [dev-dependencies]
-sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.2" }
 egui = "0.16"
 
 [features]
 cgb = ["gb-bus/cgb"]
-serialization = ["serde", "serde/std", "serde/derive", "serde/rc", "serde-big-array"]
+serialization = [
+  "serde",
+  "serde/std",
+  "serde/derive",
+  "serde/rc",
+  "serde-big-array",
+]

--- a/gb-ppu/Cargo.toml
+++ b/gb-ppu/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["std", "derive", "rc"], optional = true }
 serde-big-array = { version = "0.3", optional = true }
 
 [dev-dependencies]
-sdl2 = { version = "0.35", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.0", features = ["bundled", "static-link"] }
 egui = "0.16"
 
 [features]


### PR DESCRIPTION
Revert to use older version of `sdl2` to remain compatible on MacOS