### PR TITLE
In fast mode, the frame finished wasn't checked every second cycles

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -249,7 +249,7 @@ impl Game {
                     &mut self.cpu,
                     self.timer.borrow_mut().deref_mut(),
                     self.dma.borrow_mut().deref_mut()
-                );
+                ) && frame_not_finished;
                 self.check_scheduled_stop(!frame_not_finished);
             }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -229,7 +229,8 @@ impl Game {
                 .borrow_mut()
                 .check_hdma_state(&mut self.cpu, &self.ppu);
 
-            let frame_not_finished = cycles!(
+            #[allow(unused_mut)]
+            let mut frame_not_finished = cycles!(
                 self.clock,
                 &mut self.addr_bus,
                 self.timer.borrow_mut().deref_mut(),
@@ -242,7 +243,7 @@ impl Game {
             self.check_scheduled_stop(!frame_not_finished);
             #[cfg(feature = "cgb")]
             if self.cpu.io_regs.borrow().fast_mode() {
-                cycles!(
+                frame_not_finished = cycles!(
                     self.clock,
                     &mut self.addr_bus,
                     &mut self.cpu,


### PR DESCRIPTION
Fixes only no-bios mode. When the emu is run with the bios, there is still a loop