### PR TITLE
fix game not paused when starting the debugger in the cli

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -92,7 +92,7 @@ impl Context {
         if reload_mode || reload_file {
             self.config.mode = config.mode;
             if let Some(file) = config_file.or_else(|| self.config.rom_file.clone()) {
-                self.load(file)
+                self.load(file, open_debugger);
             } else {
                 log::warn!("Oh, I was expecting a file or something");
             }
@@ -307,8 +307,8 @@ impl Context {
 }
 
 impl Context {
-    pub fn load(&mut self, file: PathBuf) {
-        match Game::new(&file, self.joypad_config.clone(), false, self.config.mode) {
+    pub fn load(&mut self, file: PathBuf, stopped: bool) {
+        match Game::new(&file, self.joypad_config.clone(), stopped, self.config.mode) {
             Ok(game) => {
                 self.game.replace(game);
                 self.config.rom_file.replace(file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn handle_custom_event(
 ) {
     match event {
         CustomEvent::Quit => *control_flow = ControlFlow::Exit,
-        CustomEvent::LoadFile(file) => context.load(file),
+        CustomEvent::LoadFile(file) => context.load(file, context.debugger_ctx.is_some()),
         CustomEvent::OpenWindow(window_type) => context
             .open_window(window_type, event_loop)
             .unwrap_or_else(|ref err| log::error!("Failed to open new window: {:?}", err)),


### PR DESCRIPTION
- when we load a game from the CLI and also start the debugger (`-d`)
  the game is now paused
- when the debugger is openned and we load a new rom,
  the new game will be paused at the start.

close #699 